### PR TITLE
chore: ci 실패시 discord로 알림을 보내는 step 추가

### DIFF
--- a/.github/workflows/dev_build_validation.yml
+++ b/.github/workflows/dev_build_validation.yml
@@ -36,3 +36,32 @@ jobs:
       # 4. Gradle 빌드 실행
       - name: Build with Gradle
         run: ./gradlew build -x test
+
+      # CI 실패 시 디스코드 알림
+      - name: Notify Failure on Discord
+        if: ${{ failure() }}
+        uses: Ilshidur/action-discord@0.3.2
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_SERVER_CI}}
+          DISCORD_USERNAME: CI_CAT
+          DISCORD_AVATAR: https://github.com/user-attachments/assets/f4a333ae-c6e0-43ed-abe7-4e50a519a3be
+          DISCORD_EMBEDS: |
+            [
+              {
+                "title": "빌드 실패했다냥 ❌",
+                "color": 15158332,
+                "description": "[#${{ github.event.pull_request.number }}] ${{ github.event.pull_request.title }}\n${{ github.event.pull_request.html_url }}",
+                "fields": [
+                  {
+                    "name": "브랜치",
+                    "value": "${{ github.ref }}",
+                    "inline": true
+                  },
+                  {
+                    "name": "작성자",
+                    "value": "${{ github.event.pull_request.user.login }}",
+                    "inline": true
+                  }
+                ]
+              }
+            ]


### PR DESCRIPTION
## ✅ PR 체크리스트
- [ ] Assignee를 지정했나요?
- [ ] 병합 브랜치를 확인했나요?
- [ ] 관련 이슈를 연결했나요?
- [ ] 로컬 빌드에 성공했나요?

## 📝 변경 내용
- ci 실패시 discord로 알림을 보내는 step 추가

## 📎 관련 이슈
- close #