### PR TITLE
feat: self-signed SSL 인증서를 사용하여 HTTPS 통신 활성화

### DIFF
--- a/src/main/java/com/parksupark/soomjae/server/auth/common/jwt/DefaultJwtParser.java
+++ b/src/main/java/com/parksupark/soomjae/server/auth/common/jwt/DefaultJwtParser.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class DefaultJwtParser extends AbstractJwtKeyHolder implements JwtParser {
 
-    public DefaultJwtParser(@Value("{jwt.secret}") String secret) {
+    public DefaultJwtParser(@Value("${jwt.secret}") String secret) {
         super(secret);
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,16 @@
 # ===============================
 # Spring Boot
 # ===============================
-server.port=8080
+server.port=8443
+
+# SSL 활성화
+server.ssl.enabled=true
+
+# keystore 설정
+server.ssl.key-store=classpath:keystore.p12
+server.ssl.key-store-type=PKCS12
+server.ssl.key-store-password=${KEYSTORE_PASSWORD}
+server.ssl.key-alias=${KEYSTORE_ALIAS}
 
 spring.config.import=optional:file:.env[.properties]
 
@@ -13,7 +22,7 @@ spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
 
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
-spring.jpa.hibernate.ddl-auto=none
+spring.jpa.hibernate.ddl-auto=create
 spring.jpa.show-sql=true
 
 # ========= Google OAuth2 =========


### PR DESCRIPTION
## ✅ PR 체크리스트
- [x] Assignee를 지정했나요?
- [x] 병합 브랜치를 확인했나요?
- [x] 관련 이슈를 연결했나요?
- [x] 로컬 빌드에 성공했나요?

## 📝 변경 내용
- self-signed SSL 인증서를 생성 및 등록해 HTTPS 요청을 처리하도록 수정하였습니다.
- keystore 파일과 KEYSTORE_PASSWORD, KEYSTORE_ALIAS 를 환경 변수로 등록해야 합니다. 디스코드에 남겨두겠습니다.
- 통신 프로토콜, port 번호가 변경됨에 따라 postman api 명세서의 baseUrl을 변경해야 합니다. **https://localhost:8443**

## 📎 관련 이슈
- close #34 