### PR TITLE
feat: username/password 로그인 성공 응답에 memberId 포함

### DIFF
--- a/src/main/java/com/parksupark/soomjae/server/auth/common/jwt/DefaultJwtGenerator.java
+++ b/src/main/java/com/parksupark/soomjae/server/auth/common/jwt/DefaultJwtGenerator.java
@@ -1,8 +1,8 @@
 package com.parksupark.soomjae.server.auth.common.jwt;
 
-import com.parksupark.soomjae.server.member.Role;
 import io.jsonwebtoken.Jwts;
 import java.util.Date;
+import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -14,14 +14,14 @@ public class DefaultJwtGenerator extends AbstractJwtKeyHolder implements JwtGene
     }
 
     @Override
-    public String generate(String subject, Role role) {
+    public String generate(String subject, Map<String, Object> claims) {
         long nowMillis = System.currentTimeMillis();
         Date now = new Date(nowMillis);
         Date expiry = new Date(nowMillis + 1000 * 60 * 60);
 
         return Jwts.builder()
             .subject(subject)
-            .claim("role", role.getKey())
+            .claims(claims)
             .issuedAt(now)
             .expiration(expiry)
             .signWith(key)

--- a/src/main/java/com/parksupark/soomjae/server/auth/common/jwt/JwtGenerator.java
+++ b/src/main/java/com/parksupark/soomjae/server/auth/common/jwt/JwtGenerator.java
@@ -1,8 +1,8 @@
 package com.parksupark.soomjae.server.auth.common.jwt;
 
-import com.parksupark.soomjae.server.member.Role;
+import java.util.Map;
 
 public interface JwtGenerator {
 
-    String generate(String subject, Role role);
+    String generate(String subject, Map<String, Object> claims);
 }

--- a/src/main/java/com/parksupark/soomjae/server/auth/common/jwt/JwtProvider.java
+++ b/src/main/java/com/parksupark/soomjae/server/auth/common/jwt/JwtProvider.java
@@ -1,11 +1,11 @@
 package com.parksupark.soomjae.server.auth.common.jwt;
 
-import com.parksupark.soomjae.server.member.Role;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Date;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -24,8 +24,8 @@ public class JwtProvider {
     private final JwtParser jwtParser;
 
 
-    public String generateToken(String subject, Role role) {
-        return jwtGenerator.generate(subject, role);
+    public String generateToken(String subject, Map<String, Object> claims) {
+        return jwtGenerator.generate(subject, claims);
     }
 
     public Authentication getAuthentication(String token) {

--- a/src/main/java/com/parksupark/soomjae/server/auth/username/dto/UsernamePasswordAuthSuccessResponse.java
+++ b/src/main/java/com/parksupark/soomjae/server/auth/username/dto/UsernamePasswordAuthSuccessResponse.java
@@ -7,8 +7,10 @@ public class UsernamePasswordAuthSuccessResponse {
 
     private final String accessToken;
     private final String tokenType = "Bearer";
+    private final Long memberId;
 
-    public UsernamePasswordAuthSuccessResponse(String accessToken) {
+    public UsernamePasswordAuthSuccessResponse(String accessToken, Long memberId) {
         this.accessToken = accessToken;
+        this.memberId = memberId;
     }
 }

--- a/src/main/java/com/parksupark/soomjae/server/auth/username/filter/UsernamePasswordLoginFilter.java
+++ b/src/main/java/com/parksupark/soomjae/server/auth/username/filter/UsernamePasswordLoginFilter.java
@@ -7,11 +7,14 @@ import com.parksupark.soomjae.server.auth.username.dto.UsernamePasswordAuthSucce
 import com.parksupark.soomjae.server.auth.username.dto.UsernamePasswordLoginRequest;
 import com.parksupark.soomjae.server.auth.username.dto.UsernamePasswordUserDetails;
 import com.parksupark.soomjae.server.member.Role;
+import com.parksupark.soomjae.server.member.entity.Member;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -60,17 +63,21 @@ public class UsernamePasswordLoginFilter extends UsernamePasswordAuthenticationF
     protected void successfulAuthentication(HttpServletRequest request,
         HttpServletResponse response, FilterChain chain, Authentication authResult)
         throws IOException, ServletException {
+        Map<String, Object> claims = new HashMap<>();
 
-        UsernamePasswordUserDetails principal =
+        UsernamePasswordUserDetails userDetails =
             (UsernamePasswordUserDetails) authResult.getPrincipal();
+        Member member = userDetails.getMember();
 
-        String username = principal.getUsername();
-        Role role = principal.getMember().getRole();
+        String username = userDetails.getUsername();
+        Role role = member.getRole();
 
-        String token = jwtProvider.generateToken(username, role);
+        claims.put("role", role.getKey());
+
+        String token = jwtProvider.generateToken(username, claims);
 
         UsernamePasswordAuthSuccessResponse successResponse =
-            new UsernamePasswordAuthSuccessResponse(token);
+            new UsernamePasswordAuthSuccessResponse(token, member.getId());
 
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");

--- a/src/main/java/com/parksupark/soomjae/server/member/entity/Member.java
+++ b/src/main/java/com/parksupark/soomjae/server/member/entity/Member.java
@@ -40,5 +40,5 @@ public class Member {
     public static Member create(String email, String password) {
         return new Member(email, password, Role.USER);
     }
-
+    
 }

--- a/src/test/java/com/parksupark/soomjae/server/auth/common/jwt/JwtProviderTest.java
+++ b/src/test/java/com/parksupark/soomjae/server/auth/common/jwt/JwtProviderTest.java
@@ -9,6 +9,8 @@ import com.parksupark.soomjae.server.auth.username.service.UsernamePasswordUserD
 import com.parksupark.soomjae.server.member.Role;
 import com.parksupark.soomjae.server.member.entity.Member;
 import io.jsonwebtoken.Claims;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -21,12 +23,19 @@ class JwtProviderTest {
     @Mock
     private UsernamePasswordUserDetailsService userDetailsService;
 
+    private final Map<String, Object> claimsWithRole = new HashMap<>() {
+        {
+            put("role", Role.USER.getKey());
+        }
+    };
+
     @Test
     void generator_shouldCreate_validSignedJwt() {
         final String username = "test username";
+
         JwtProvider jwtProvider = JwtTestHelper.getDefaultFwtProvider(userDetailsService);
 
-        String token = jwtProvider.generateToken(username, Role.USER);
+        String token = jwtProvider.generateToken(username, claimsWithRole);
 
         Claims claims = jwtProvider.getClaimsFromToken(token);
 
@@ -42,7 +51,7 @@ class JwtProviderTest {
 
         JwtProvider jwtProvider = JwtTestHelper.getDefaultFwtProvider(userDetailsService);
 
-        String token = jwtProvider.generateToken(username, Role.USER);
+        String token = jwtProvider.generateToken(username, claimsWithRole);
 
         UsernamePasswordUserDetails userDetails = new UsernamePasswordUserDetails(
             Member.create(username, "password"));
@@ -60,7 +69,7 @@ class JwtProviderTest {
         final String username = "expired_user";
 
         JwtProvider jwtProvider = JwtTestHelper.getExpiredJwtProvider(userDetailsService);
-        String token = jwtProvider.generateToken(username, Role.USER);
+        String token = jwtProvider.generateToken(username, claimsWithRole);
 
         assertFalse(jwtProvider.validateToken(token));
     }

--- a/src/test/java/com/parksupark/soomjae/server/auth/common/jwt/filter/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/parksupark/soomjae/server/auth/common/jwt/filter/JwtAuthenticationFilterTest.java
@@ -12,6 +12,8 @@ import com.parksupark.soomjae.server.member.entity.Member;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,6 +38,12 @@ class JwtAuthenticationFilterTest {
     @Mock
     private FilterChain filterChain;
 
+    private final Map<String, Object> claimsWithRole = new HashMap<>() {
+        {
+            put("role", Role.USER.getKey());
+        }
+    };
+
     @AfterEach
     void clearContext() {
         SecurityContextHolder.clearContext();
@@ -51,7 +59,7 @@ class JwtAuthenticationFilterTest {
         JwtProvider jwtProvider = JwtTestHelper.getDefaultFwtProvider(userDetailsService);
         JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtProvider);
 
-        String token = jwtProvider.generateToken(username, Role.USER);
+        String token = jwtProvider.generateToken(username, claimsWithRole);
 
         when(request.getHeader("Authorization")).thenReturn("Bearer " + token);
         when(userDetailsService.loadUserByUsername(username)).thenReturn(userDetails);

--- a/src/test/java/com/parksupark/soomjae/server/auth/common/jwt/stub/ExpiredJwtGenerator.java
+++ b/src/test/java/com/parksupark/soomjae/server/auth/common/jwt/stub/ExpiredJwtGenerator.java
@@ -2,9 +2,9 @@ package com.parksupark.soomjae.server.auth.common.jwt.stub;
 
 import com.parksupark.soomjae.server.auth.common.jwt.AbstractJwtKeyHolder;
 import com.parksupark.soomjae.server.auth.common.jwt.JwtGenerator;
-import com.parksupark.soomjae.server.member.Role;
 import io.jsonwebtoken.Jwts;
 import java.util.Date;
+import java.util.Map;
 
 public class ExpiredJwtGenerator extends AbstractJwtKeyHolder implements JwtGenerator {
 
@@ -13,14 +13,14 @@ public class ExpiredJwtGenerator extends AbstractJwtKeyHolder implements JwtGene
     }
 
     @Override
-    public String generate(String subject, Role role) {
+    public String generate(String subject, Map<String, Object> claims) {
         long nowMillis = System.currentTimeMillis();
         Date now = new Date(nowMillis);
         Date expiry = new Date(nowMillis - 1000 * 60);
 
         return Jwts.builder()
             .subject(subject)
-            .claim("role", role.getKey())
+            .claims(claims)
             .issuedAt(now)
             .expiration(expiry)
             .signWith(key)

--- a/src/test/java/com/parksupark/soomjae/server/auth/username/filter/UsernamePasswordLoginFilterTest.java
+++ b/src/test/java/com/parksupark/soomjae/server/auth/username/filter/UsernamePasswordLoginFilterTest.java
@@ -8,8 +8,12 @@ import com.parksupark.soomjae.server.auth.common.exception.FilterAuthenticationF
 import com.parksupark.soomjae.server.auth.common.jwt.JwtProvider;
 import com.parksupark.soomjae.server.auth.username.dto.UsernamePasswordAuthSuccessResponse;
 import com.parksupark.soomjae.server.auth.username.dto.UsernamePasswordLoginRequest;
+import com.parksupark.soomjae.server.auth.username.dto.UsernamePasswordUserDetails;
 import com.parksupark.soomjae.server.member.Role;
+import com.parksupark.soomjae.server.member.entity.Member;
 import jakarta.servlet.FilterChain;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,6 +37,12 @@ class UsernamePasswordLoginFilterTest {
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     private UsernamePasswordLoginFilter filter;
+
+    private final Map<String, Object> claimsWithRole = new HashMap<>() {
+        {
+            put("role", Role.USER.getKey());
+        }
+    };
 
     @BeforeEach
     void setUp() {
@@ -103,18 +113,22 @@ class UsernamePasswordLoginFilterTest {
         MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpServletResponse response = new MockHttpServletResponse();
         FilterChain filterChain = mock(FilterChain.class);
+        Member member = mock(Member.class);
 
         Authentication authResult = mock(Authentication.class);
 
-        when(authResult.getName()).thenReturn(username);
+        when(authResult.getPrincipal()).thenReturn(new UsernamePasswordUserDetails(member));
+        when(member.getEmail()).thenReturn(username);
+        when(member.getRole()).thenReturn(Role.USER);
+        when(member.getId()).thenReturn(1L);
 
-        when(jwtProvider.generateToken(username, Role.USER)).thenReturn(fakeToken);
+        when(jwtProvider.generateToken(username, claimsWithRole)).thenReturn(fakeToken);
 
         filter.successfulAuthentication(request, response, filterChain, authResult);
 
         String expectedResponseJson = objectMapper.writeValueAsString(
-            new UsernamePasswordAuthSuccessResponse(fakeToken));
-        assertEquals(response.getContentAsString(), expectedResponseJson);
+            new UsernamePasswordAuthSuccessResponse(fakeToken, 1L));
+        assertEquals(expectedResponseJson, response.getContentAsString());
         assertEquals("UTF-8", response.getCharacterEncoding());
         assertEquals("application/json;charset=UTF-8", response.getContentType());
 


### PR DESCRIPTION
## ✅ PR 체크리스트
- [x] Assignee를 지정했나요?
- [x] 병합 브랜치를 확인했나요?
- [x] 관련 이슈를 연결했나요?
- [x] 로컬 빌드에 성공했나요?

## 📝 변경 내용
- username/password 로그인 성공 응답에 memberId 포함하도록 수정
- token 생성시 claims 정보를 Map 으로 한번에 전달 받게 리팩토링

## 📎 관련 이슈
- close #39 