### PR TITLE
feat: Member 도메인 요청 dto Validation 기능 적용 및 테스트 코드 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.4'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'

--- a/src/main/java/com/parksupark/soomjae/server/auth/username/security/UsernamePasswordSecurityConfig.java
+++ b/src/main/java/com/parksupark/soomjae/server/auth/username/security/UsernamePasswordSecurityConfig.java
@@ -58,7 +58,7 @@ public class UsernamePasswordSecurityConfig {
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/login", "/v1/create-member").permitAll()
+                        .requestMatchers("/auth/login", "/v1/members/create-member").permitAll()
                         .anyRequest().permitAll()
                 )
 

--- a/src/main/java/com/parksupark/soomjae/server/common/constant/ValidationMessages.java
+++ b/src/main/java/com/parksupark/soomjae/server/common/constant/ValidationMessages.java
@@ -1,0 +1,18 @@
+package com.parksupark.soomjae.server.common.constant;
+
+public class ValidationMessages {
+
+    // 필수 값
+    public static final String REQUIRED = "필수 항복입니다.";
+    public static final String NOT_BLANK = "빈 값은 허용되지 않습니다.";
+    public static final String NOT_NULL = "null 값은 허용되지 않습니다.";
+    public static final String NOT_EMPTY = "비어있을 수 없습니다.";
+
+    // 이메일
+    public static final String EMAIL_INVALID_FORMAT = "올바른 이메일 형식이 아닙니다.";
+
+    private ValidationMessages() {
+
+    }
+
+}

--- a/src/main/java/com/parksupark/soomjae/server/common/dto/ValidationErrorDetail.java
+++ b/src/main/java/com/parksupark/soomjae/server/common/dto/ValidationErrorDetail.java
@@ -1,0 +1,25 @@
+package com.parksupark.soomjae.server.common.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class ValidationErrorDetail {
+
+    private final String field;
+    private final Object rejectedValue;
+    private final String message;
+
+    @JsonCreator
+    public ValidationErrorDetail(
+        @JsonProperty String field,
+        @JsonProperty Object rejectedValue,
+        @JsonProperty String message
+    ) {
+        this.field = field;
+        this.rejectedValue = rejectedValue;
+        this.message = message;
+    }
+
+}

--- a/src/main/java/com/parksupark/soomjae/server/common/dto/ValidationErrorResponse.java
+++ b/src/main/java/com/parksupark/soomjae/server/common/dto/ValidationErrorResponse.java
@@ -1,0 +1,23 @@
+package com.parksupark.soomjae.server.common.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class ValidationErrorResponse {
+
+    private final String message;
+    private final List<ValidationErrorDetail> errors;
+
+    @JsonCreator
+    public ValidationErrorResponse(
+        @JsonProperty String message,
+        @JsonProperty List<ValidationErrorDetail> errors
+    ) {
+        this.message = message;
+        this.errors = errors;
+    }
+
+}

--- a/src/main/java/com/parksupark/soomjae/server/common/exception/ErrorMessages.java
+++ b/src/main/java/com/parksupark/soomjae/server/common/exception/ErrorMessages.java
@@ -11,6 +11,9 @@ public class ErrorMessages {
     public static final String DATA_INTEGRITY_VIOLATION_EXCEPTION_MESSAGE = "엔티티 레벨 unique 검증 실패";
 
 
+    public static final String VALIDATION_FAILED_MESSAGE = "요청 바디 값 검증에 실패했습니다.";
+
+
     private ErrorMessages() {
     }
 }

--- a/src/main/java/com/parksupark/soomjae/server/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/parksupark/soomjae/server/common/exception/GlobalExceptionHandler.java
@@ -1,13 +1,18 @@
 package com.parksupark.soomjae.server.common.exception;
 
+import com.parksupark.soomjae.server.common.dto.ValidationErrorDetail;
+import com.parksupark.soomjae.server.common.dto.ValidationErrorResponse;
 import com.parksupark.soomjae.server.community.common.exception.AlreadyLikedException;
 import com.parksupark.soomjae.server.community.common.exception.InvalidPostIdException;
 import com.parksupark.soomjae.server.community.common.exception.InvalidPostTypeException;
 import com.parksupark.soomjae.server.community.common.exception.LikeNotFoundException;
 import com.parksupark.soomjae.server.member.exception.DuplicateEmailException;
 import com.parksupark.soomjae.server.member.exception.MemberNotFoundException;
+import java.util.List;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -36,5 +41,24 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity.status(400)
             .body(ErrorMessages.DATA_INTEGRITY_VIOLATION_EXCEPTION_MESSAGE);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ValidationErrorResponse> handleValidationException(
+        MethodArgumentNotValidException e) {
+
+        List<FieldError> fieldErrors = e.getBindingResult().getFieldErrors();
+        List<ValidationErrorDetail> errors = fieldErrors.stream()
+            .map(error -> new ValidationErrorDetail(
+                error.getField(),
+                error.getRejectedValue(),
+                error.getDefaultMessage()
+            ))
+            .toList();
+
+        ValidationErrorResponse errorResponse = new ValidationErrorResponse(
+            ErrorMessages.VALIDATION_FAILED_MESSAGE, errors);
+
+        return ResponseEntity.status(400).body(errorResponse);
     }
 }

--- a/src/main/java/com/parksupark/soomjae/server/member/controller/MemberController.java
+++ b/src/main/java/com/parksupark/soomjae/server/member/controller/MemberController.java
@@ -6,6 +6,7 @@ import com.parksupark.soomjae.server.member.dto.MemberResponse;
 import com.parksupark.soomjae.server.member.dto.PatchEmailRequest;
 import com.parksupark.soomjae.server.member.dto.PatchNicknameRequest;
 import com.parksupark.soomjae.server.member.service.MemberService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -27,7 +28,7 @@ public class MemberController {
 
     @PostMapping("/create-member")
     public ResponseEntity<MemberResponse> postMember(
-        @RequestBody CreateMemberRequest request) {
+        @RequestBody @Valid CreateMemberRequest request) {
         MemberResponse response = memberService.createMember(request);
         return ResponseEntity.ok(response);
     }
@@ -54,7 +55,7 @@ public class MemberController {
     @PreAuthorize(value = "isAuthenticated()")
     public ResponseEntity<MemberResponse> patchMemberEmail(
         @AuthenticationPrincipal UsernamePasswordUserDetails userDetails,
-        @RequestBody PatchEmailRequest request
+        @RequestBody @Valid PatchEmailRequest request
     ) {
         String email = request.getEmail();
         Long memberId = userDetails.getMember().getId();
@@ -70,7 +71,7 @@ public class MemberController {
     @PreAuthorize(value = "isAuthenticated()")
     public ResponseEntity<MemberResponse> patchMemberNickname(
         @AuthenticationPrincipal UsernamePasswordUserDetails userDetails,
-        @RequestBody PatchNicknameRequest request
+        @RequestBody @Valid PatchNicknameRequest request
     ) {
         Long memberId = userDetails.getMember().getId();
         String nickname = request.getNickname();

--- a/src/main/java/com/parksupark/soomjae/server/member/dto/CreateMemberRequest.java
+++ b/src/main/java/com/parksupark/soomjae/server/member/dto/CreateMemberRequest.java
@@ -1,14 +1,27 @@
 package com.parksupark.soomjae.server.member.dto;
 
+import static com.parksupark.soomjae.server.common.constant.ValidationMessages.EMAIL_INVALID_FORMAT;
+import static com.parksupark.soomjae.server.common.constant.ValidationMessages.NOT_BLANK;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
 public class CreateMemberRequest {
 
+    @NotBlank(message = NOT_BLANK)
+    @Email(message = EMAIL_INVALID_FORMAT)
     private final String email;
+
+    // 비밀번호 패턴 정책 확립후 Validation 적용
+    @NotBlank(message = NOT_BLANK)
     private final String password;
+
+    // 닉네임 패턴 정책 확립후 Validation 적용
+    @NotBlank(message = NOT_BLANK)
     private final String nickname;
 
     @JsonCreator

--- a/src/main/java/com/parksupark/soomjae/server/member/dto/MemberResponse.java
+++ b/src/main/java/com/parksupark/soomjae/server/member/dto/MemberResponse.java
@@ -1,10 +1,16 @@
 package com.parksupark.soomjae.server.member.dto;
 
-import lombok.Data;
+import lombok.Getter;
 
-@Data
+@Getter
 public class MemberResponse {
     private final Long memberId;
     private final String email;
     private final String nickname;
+
+    public MemberResponse(Long memberId, String email, String nickname) {
+        this.memberId = memberId;
+        this.email = email;
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/com/parksupark/soomjae/server/member/dto/PatchEmailRequest.java
+++ b/src/main/java/com/parksupark/soomjae/server/member/dto/PatchEmailRequest.java
@@ -1,12 +1,19 @@
 package com.parksupark.soomjae.server.member.dto;
 
+import static com.parksupark.soomjae.server.common.constant.ValidationMessages.EMAIL_INVALID_FORMAT;
+import static com.parksupark.soomjae.server.common.constant.ValidationMessages.NOT_BLANK;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
 public class PatchEmailRequest {
 
+    @NotBlank(message = NOT_BLANK)
+    @Email(message = EMAIL_INVALID_FORMAT)
     private final String email;
 
     @JsonCreator

--- a/src/main/java/com/parksupark/soomjae/server/member/dto/PatchNicknameRequest.java
+++ b/src/main/java/com/parksupark/soomjae/server/member/dto/PatchNicknameRequest.java
@@ -1,12 +1,16 @@
 package com.parksupark.soomjae.server.member.dto;
 
+import static com.parksupark.soomjae.server.common.constant.ValidationMessages.NOT_BLANK;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
 public class PatchNicknameRequest {
 
+    @NotBlank(message = NOT_BLANK)
     private final String nickname;
 
     @JsonCreator

--- a/src/main/java/com/parksupark/soomjae/server/member/service/DefaultMemberService.java
+++ b/src/main/java/com/parksupark/soomjae/server/member/service/DefaultMemberService.java
@@ -26,10 +26,11 @@ public class DefaultMemberService implements MemberService {
     @Override
     public MemberResponse createMember(CreateMemberRequest request) {
         final String email = request.getEmail();
-        final String encodedPassword = passwordEncoder.encode(request.getPassword());
-        final String nickname = request.getNickname();
 
         checkDuplicateEmail(email);
+
+        final String encodedPassword = passwordEncoder.encode(request.getPassword());
+        final String nickname = request.getNickname();
 
         Member member = Member.create(email, encodedPassword, nickname);
         memberRepository.save(member);

--- a/src/test/java/com/parksupark/soomjae/server/member/MemberControllerValidationTest.java
+++ b/src/test/java/com/parksupark/soomjae/server/member/MemberControllerValidationTest.java
@@ -1,0 +1,118 @@
+package com.parksupark.soomjae.server.member;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.parksupark.soomjae.server.member.controller.MemberController;
+import com.parksupark.soomjae.server.member.dto.CreateMemberRequest;
+import com.parksupark.soomjae.server.member.service.MemberService;
+import com.parksupark.soomjae.server.member.service.NoOpMemberService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(MemberController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class MemberControllerValidationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @TestConfiguration
+    static class Config {
+
+        @Bean
+        @Primary
+        public MemberService memberService() {
+            return new NoOpMemberService();
+        }
+    }
+
+    // === 유효한 값들 ===
+    private static final String VALID_EMAIL = "test@example.com";
+    private static final String VALID_PASSWORD = "validPassword123";
+    private static final String VALID_NICKNAME = "validNickname";
+
+    // === 유효하지 않은 값들 ===
+    private static final String EMPTY_VALUE = "";
+    private static final String WHITESPACE_VALUE = "   ";
+    private static final String INVALID_EMAIL_FORMAT = "invalid-email-format";
+
+    // === API 엔드포인트 ===
+    private static final String POST_MEMBER_URI = "/v1/members/create-member";
+
+    @Test
+    @DisplayName("유효한 형식으로 postMember 호출시")
+    void postMemberWithValidData_shouldReturnOk() throws Exception {
+        // given
+        CreateMemberRequest request = new CreateMemberRequest(VALID_EMAIL, VALID_PASSWORD,
+            VALID_NICKNAME);
+
+        // when + then
+        mockMvc.perform(post(POST_MEMBER_URI)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andDo(print())
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 이메일 형식으로 postMember 호출시")
+    void postMemberWithInvalidEmailFormat_shouldReturnBadRequest() throws Exception {
+        // given
+        CreateMemberRequest invalidEmailFormatRequest = new CreateMemberRequest(
+            INVALID_EMAIL_FORMAT,
+            VALID_PASSWORD,
+            VALID_NICKNAME);
+
+        // when + then
+        mockMvc.perform(post(POST_MEMBER_URI)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(invalidEmailFormatRequest)))
+            .andDo(print())
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("공백이 포함된 필드값으로 postMember 호출시")
+    void postMemberWithWhitespaceField_shouldReturnBadRequest() throws Exception {
+        // given
+        CreateMemberRequest blankSpaceRequest = new CreateMemberRequest(WHITESPACE_VALUE,
+            WHITESPACE_VALUE,
+            WHITESPACE_VALUE);
+
+        // when + then
+        mockMvc.perform(post(POST_MEMBER_URI)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(blankSpaceRequest)))
+            .andDo(print())
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("빈 필드값으로 postMember 호출시")
+    void postMemberWithEmptyField_shouldReturnBadRequest() throws Exception {
+        // given
+        CreateMemberRequest request = new CreateMemberRequest(EMPTY_VALUE, EMPTY_VALUE,
+            EMPTY_VALUE);
+
+        // when + then
+        mockMvc.perform(post(POST_MEMBER_URI)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andDo(print())
+            .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/parksupark/soomjae/server/member/service/NoOpMemberService.java
+++ b/src/test/java/com/parksupark/soomjae/server/member/service/NoOpMemberService.java
@@ -1,0 +1,32 @@
+package com.parksupark.soomjae.server.member.service;
+
+import com.parksupark.soomjae.server.member.dto.CreateMemberRequest;
+import com.parksupark.soomjae.server.member.dto.MemberResponse;
+
+public class NoOpMemberService implements MemberService {
+
+    @Override
+    public MemberResponse updateNickname(Long id, String nickname) {
+        return null;
+    }
+
+    @Override
+    public MemberResponse updatePassword(Long id, String password) {
+        return null;
+    }
+
+    @Override
+    public MemberResponse updateEmail(Long id, String email) {
+        return null;
+    }
+
+    @Override
+    public MemberResponse readMember(Long id) {
+        return null;
+    }
+
+    @Override
+    public MemberResponse createMember(CreateMemberRequest request) {
+        return null;
+    }
+}


### PR DESCRIPTION
## ✅ PR 체크리스트
- [x] Assignee를 지정했나요?
- [x] 병합 브랜치를 확인했나요?
- [x] 관련 이슈를 연결했나요?
- [x] 로컬 빌드에 성공했나요?

## 📝 변경 내용
- Member 도메인 요청 dto 클래스의 필드값들에 Validation 을 적용하였습니다.
- MemberController 에 들어오는 요청 바디의 검증 테스트 코드를 작성하였습니다.
- 비밀번호 정책, nickname 정책이 확립되면 그에 맞는 Validation 을 dto 클래스와 entity 클래스에 적용시키겠습니다.

## 📎 관련 이슈
- close #65 