### PR TITLE
feat: 데이터베이스에 시간 정보를 UTC 형식으로 저장 & API 응답에 UTC 형식으로 응답하도록 수정

### DIFF
--- a/src/main/java/com/parksupark/soomjae/server/common/entity/BaseEntity.java
+++ b/src/main/java/com/parksupark/soomjae/server/common/entity/BaseEntity.java
@@ -3,7 +3,7 @@ package com.parksupark.soomjae.server.common.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -16,15 +16,15 @@ public abstract class BaseEntity {
 
     @CreatedDate
     @Column(updatable = false)
-    private LocalDateTime createdTime;
+    private Instant createdTime;
 
     @LastModifiedDate
-    private LocalDateTime modifiedTime;
+    private Instant modifiedTime;
 
-    private LocalDateTime deletedTime;
+    private Instant deletedTime;
 
     public void markDeleted() {
-        this.deletedTime = LocalDateTime.now();
+        this.deletedTime = Instant.now();
     }
     // getter 생략 가능 (필요시 추가)
 }

--- a/src/main/java/com/parksupark/soomjae/server/community/communitypost/dto/CommunityPostResponse.java
+++ b/src/main/java/com/parksupark/soomjae/server/community/communitypost/dto/CommunityPostResponse.java
@@ -5,6 +5,7 @@ import com.parksupark.soomjae.server.community.communitypost.entity.CommunityPos
 import com.parksupark.soomjae.server.community.location.entity.Location;
 import com.parksupark.soomjae.server.member.dto.MemberResponse;
 import com.parksupark.soomjae.server.member.entity.Member;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
@@ -25,10 +26,10 @@ public class CommunityPostResponse {
 
     private String category;
     private String location;
-    private LocalDateTime createdTime;
+    private Instant createdTime;
 
     public CommunityPostResponse(Long postId, String title, String content,
-            MemberResponse author, LocalDateTime createdTime) {
+            MemberResponse author, Instant createdTime) {
         this.postId = postId;
         this.postType = "community";
         this.title = title;
@@ -43,7 +44,8 @@ public class CommunityPostResponse {
         CommunityPostResponse communityPostResponse = new CommunityPostResponse(
             communityPost.getId(), communityPost.getTitle(),
             communityPost.getContent(),
-            new MemberResponse(author.getId(), author.getEmail(), author.getNickname()),
+            new MemberResponse(author.getId(), author.getEmail(), author.getNickname(),
+                author.getCreatedTime(), author.getModifiedTime()),
             communityPost.getCreatedTime());
 
 

--- a/src/main/java/com/parksupark/soomjae/server/member/dto/MemberResponse.java
+++ b/src/main/java/com/parksupark/soomjae/server/member/dto/MemberResponse.java
@@ -1,13 +1,21 @@
 package com.parksupark.soomjae.server.member.dto;
 
 import java.time.Instant;
-import lombok.Data;
+import lombok.Getter;
 
-@Data
+@Getter
 public class MemberResponse {
     private final Long memberId;
     private final String email;
     private final String nickname;
     private final Instant createdTime;
     private final Instant modifiedTime;
+
+    public MemberResponse(Long memberId, String email, String nickname, Instant createdTime, Instant modifiedTime) {
+        this.memberId = memberId;
+        this.email = email;
+        this.nickname = nickname;
+        this.createdTime = createdTime;
+        this.modifiedTime = modifiedTime;
+    }
 }

--- a/src/main/java/com/parksupark/soomjae/server/member/dto/MemberResponse.java
+++ b/src/main/java/com/parksupark/soomjae/server/member/dto/MemberResponse.java
@@ -11,7 +11,9 @@ public class MemberResponse {
     private final Instant createdTime;
     private final Instant modifiedTime;
 
-    public MemberResponse(Long memberId, String email, String nickname, Instant createdTime, Instant modifiedTime) {
+    public MemberResponse(Long memberId, String email, String nickname,
+                          Instant createdTime, Instant modifiedTime) {
+        
         this.memberId = memberId;
         this.email = email;
         this.nickname = nickname;

--- a/src/main/java/com/parksupark/soomjae/server/member/dto/MemberResponse.java
+++ b/src/main/java/com/parksupark/soomjae/server/member/dto/MemberResponse.java
@@ -1,5 +1,6 @@
 package com.parksupark.soomjae.server.member.dto;
 
+import java.time.Instant;
 import lombok.Data;
 
 @Data
@@ -7,4 +8,6 @@ public class MemberResponse {
     private final Long memberId;
     private final String email;
     private final String nickname;
+    private final Instant createdTime;
+    private final Instant modifiedTime;
 }

--- a/src/main/java/com/parksupark/soomjae/server/member/entity/Member.java
+++ b/src/main/java/com/parksupark/soomjae/server/member/entity/Member.java
@@ -1,5 +1,6 @@
 package com.parksupark.soomjae.server.member.entity;
 
+import com.parksupark.soomjae.server.common.entity.BaseEntity;
 import com.parksupark.soomjae.server.member.Role;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -15,7 +16,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "member")
 @Getter
 @NoArgsConstructor
-public class Member {
+public class Member extends BaseEntity {
 
     @Id
     @Column(name = "member_id")

--- a/src/main/java/com/parksupark/soomjae/server/member/service/DefaultMemberService.java
+++ b/src/main/java/com/parksupark/soomjae/server/member/service/DefaultMemberService.java
@@ -87,7 +87,8 @@ public class DefaultMemberService implements MemberService {
     }
 
     private MemberResponse createMemberResponse(Member member) {
-        return new MemberResponse(member.getId(), member.getEmail(), member.getNickname());
+        return new MemberResponse(member.getId(), member.getEmail(), member.getNickname(),
+            member.getCreatedTime(), member.getModifiedTime());
     }
 
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,12 +13,13 @@ spring.config.import=optional:file:.env[.properties]
 # ===============================
 # Database (PostgreSQL)
 # ===============================
-spring.datasource.url=${DB_URL}
+spring.datasource.url=${DB_URL}?serverTimezone=UTC
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.jdbc.time_zone=UTC
 # ========= Google OAuth2 =========
 # spring.security.oauth2.client.registration.google.client-id=
 # spring.security.oauth2.client.registration.google.client-secret=

--- a/src/test/resources/application-test2.properties
+++ b/src/test/resources/application-test2.properties
@@ -1,5 +1,5 @@
 # H2 in-memory DB 설정
-spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE?serverTimezone=UTC
 spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=
@@ -7,6 +7,7 @@ spring.datasource.password=
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.jdbc.time_zone=UTC
 # H2 콘솔(선택적, 웹 콘솔 UI 사용 시)
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,5 +1,5 @@
 # H2 in-memory DB 설정
-spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE?serverTimezone=UTC
 spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=
@@ -8,6 +8,7 @@ spring.datasource.password=
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.jdbc.time_zone=UTC
 
 # H2 콘솔(선택적, 웹 콘솔 UI 사용 시)
 spring.h2.console.enabled=true


### PR DESCRIPTION
## ✅ PR 체크리스트
- [x] Assignee를 지정했나요?
- [x] 병합 브랜치를 확인했나요?
- [x] 관련 이슈를 연결했나요?
- [x] 로컬 빌드에 성공했나요?

## 📝 변경 내용
-  데이터베이스에 시간 정보를 UTC 형식으로 저장 & API 응답에 UTC 형식으로 응답하도록 수정

## 테스트 결과
```
MockHttpServletResponse:
           Status = 200
    Error message = null
          Headers = [Content-Type:"application/json", X-Content-Type-Options:"nosniff", X-XSS-Protection:"0", Cache-Control:"no-cache, no-store, max-age=0, must-revalidate", Pragma:"no-cache", Expires:"0", X-Frame-Options:"DENY"]
     Content type = application/json
             Body = {"memberId":1,"email":"test@example.com","nickname":"testnickname","createdTime":"2025-06-30T13:07:38.519988500Z","modifiedTime":"2025-06-30T13:07:38.519988500Z"}
    Forwarded URL = null
   Redirected URL = null
          Cookies = []
```
Member 생성 테스트 결과 API 응답 값으로 UTC 형식의 시간 정보가 포함된 것을 볼 수 있습니다.

## 📎 관련 이슈
- close #67 