### PR TITLE
feat: 회원 가입시에 사용할 이메일 중복 체크 API 추가

### DIFF
--- a/src/main/java/com/parksupark/soomjae/server/auth/username/dto/UsernamePasswordAuthSuccessResponse.java
+++ b/src/main/java/com/parksupark/soomjae/server/auth/username/dto/UsernamePasswordAuthSuccessResponse.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 public class UsernamePasswordAuthSuccessResponse {
 
     private final String accessToken;
-    private final String tokenType = "Bearer";
+    private static final String TOKEN_TYPE = "Bearer";
     private final Long memberId;
 
     public UsernamePasswordAuthSuccessResponse(String accessToken, Long memberId) {

--- a/src/main/java/com/parksupark/soomjae/server/member/controller/MemberController.java
+++ b/src/main/java/com/parksupark/soomjae/server/member/controller/MemberController.java
@@ -76,7 +76,7 @@ public class MemberController {
             @RequestBody @Valid CheckDuplicateEmailRequest request
     ) {
         String email = request.getEmail();
-        CheckDuplicateEmailResponse response = memberService.isDuplicateEmail(email);
+        CheckDuplicateEmailResponse response = memberService.checkDuplicateEmail(email);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/parksupark/soomjae/server/member/controller/MemberController.java
+++ b/src/main/java/com/parksupark/soomjae/server/member/controller/MemberController.java
@@ -1,23 +1,14 @@
 package com.parksupark.soomjae.server.member.controller;
 
 import com.parksupark.soomjae.server.auth.username.dto.UsernamePasswordUserDetails;
-import com.parksupark.soomjae.server.member.dto.CreateMemberRequest;
-import com.parksupark.soomjae.server.member.dto.MemberResponse;
-import com.parksupark.soomjae.server.member.dto.PatchEmailRequest;
-import com.parksupark.soomjae.server.member.dto.PatchNicknameRequest;
+import com.parksupark.soomjae.server.member.dto.*;
 import com.parksupark.soomjae.server.member.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,6 +20,7 @@ public class MemberController {
     @PostMapping("/create-member")
     public ResponseEntity<MemberResponse> postMember(
         @RequestBody @Valid CreateMemberRequest request) {
+
         MemberResponse response = memberService.createMember(request);
         return ResponseEntity.ok(response);
     }
@@ -60,13 +52,12 @@ public class MemberController {
         String email = request.getEmail();
         Long memberId = userDetails.getMember().getId();
         MemberResponse memberResponse = memberService.updateEmail(memberId, email);
-
+        
         return ResponseEntity.ok(memberResponse);
     }
 
     // 비밀번호 변경은 현재 비밀번호 검증이 필요하므로 추후에 구현
     // nickname 중복 검증 필요?
-
     @PatchMapping("/me/update-nickname")
     @PreAuthorize(value = "isAuthenticated()")
     public ResponseEntity<MemberResponse> patchMemberNickname(
@@ -78,5 +69,15 @@ public class MemberController {
         MemberResponse memberResponse = memberService.updateNickname(memberId, nickname);
 
         return ResponseEntity.ok(memberResponse);
+    }
+
+    @PostMapping("/check-duplicate-email")
+    public ResponseEntity<CheckDuplicateEmailResponse> checkEmailAvailability(
+            @RequestBody @Valid CheckDuplicateEmailRequest request
+    ) {
+        String email = request.getEmail();
+        CheckDuplicateEmailResponse response = memberService.isDuplicateEmail(email);
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/parksupark/soomjae/server/member/dto/CheckDuplicateEmailRequest.java
+++ b/src/main/java/com/parksupark/soomjae/server/member/dto/CheckDuplicateEmailRequest.java
@@ -1,0 +1,23 @@
+package com.parksupark.soomjae.server.member.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.parksupark.soomjae.server.common.constant.ValidationMessages;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class CheckDuplicateEmailRequest {
+
+    @Email(message = ValidationMessages.EMAIL_INVALID_FORMAT)
+    @NotBlank(message = ValidationMessages.NOT_BLANK)
+    private final String email;
+
+    @JsonCreator
+    public CheckDuplicateEmailRequest(
+            @JsonProperty("email") String email
+    ) {
+        this.email = email;
+    }
+}

--- a/src/main/java/com/parksupark/soomjae/server/member/dto/CheckDuplicateEmailResponse.java
+++ b/src/main/java/com/parksupark/soomjae/server/member/dto/CheckDuplicateEmailResponse.java
@@ -7,7 +7,7 @@ public class CheckDuplicateEmailResponse {
 
     private final boolean duplicate;
 
-    public CheckDuplicateEmailResponse(boolean availability) {
-        this.duplicate = availability;
+    public CheckDuplicateEmailResponse(boolean duplicate) {
+        this.duplicate = duplicate;
     }
 }

--- a/src/main/java/com/parksupark/soomjae/server/member/dto/CheckDuplicateEmailResponse.java
+++ b/src/main/java/com/parksupark/soomjae/server/member/dto/CheckDuplicateEmailResponse.java
@@ -1,0 +1,13 @@
+package com.parksupark.soomjae.server.member.dto;
+
+import lombok.Getter;
+
+@Getter
+public class CheckDuplicateEmailResponse {
+
+    private final boolean duplicate;
+
+    public CheckDuplicateEmailResponse(boolean availability) {
+        this.duplicate = availability;
+    }
+}

--- a/src/main/java/com/parksupark/soomjae/server/member/service/DefaultMemberService.java
+++ b/src/main/java/com/parksupark/soomjae/server/member/service/DefaultMemberService.java
@@ -1,6 +1,7 @@
 package com.parksupark.soomjae.server.member.service;
 
 import com.parksupark.soomjae.server.common.exception.ErrorMessages;
+import com.parksupark.soomjae.server.member.dto.CheckDuplicateEmailResponse;
 import com.parksupark.soomjae.server.member.dto.CreateMemberRequest;
 import com.parksupark.soomjae.server.member.dto.MemberResponse;
 import com.parksupark.soomjae.server.member.entity.Member;
@@ -81,10 +82,16 @@ public class DefaultMemberService implements MemberService {
         return createMemberResponse(member);
     }
 
+    @Transactional(readOnly = true)
+    @Override
+    public CheckDuplicateEmailResponse isDuplicateEmail(String email) {
+        return new CheckDuplicateEmailResponse(memberRepository.existsByEmail(email));
+    }
+
     private Member findMemberById(Long id) {
         return memberRepository.findById(id)
-            .orElseThrow(() -> new MemberNotFoundException(
-                ErrorMessages.MEMBER_NOT_FOUND_EXCEPTION_MESSAGE));
+                .orElseThrow(() -> new MemberNotFoundException(
+                        ErrorMessages.MEMBER_NOT_FOUND_EXCEPTION_MESSAGE));
     }
 
     private MemberResponse createMemberResponse(Member member) {

--- a/src/main/java/com/parksupark/soomjae/server/member/service/DefaultMemberService.java
+++ b/src/main/java/com/parksupark/soomjae/server/member/service/DefaultMemberService.java
@@ -28,7 +28,7 @@ public class DefaultMemberService implements MemberService {
     public MemberResponse createMember(CreateMemberRequest request) {
         final String email = request.getEmail();
 
-        checkDuplicateEmail(email);
+        validateEmailUniqueness(email);
 
         final String encodedPassword = passwordEncoder.encode(request.getPassword());
         final String nickname = request.getNickname();
@@ -54,7 +54,7 @@ public class DefaultMemberService implements MemberService {
 
         Member member = findMemberById(id);
 
-        checkDuplicateEmail(email);
+        validateEmailUniqueness(email);
 
         member.updateEmail(email);
         return createMemberResponse(member);
@@ -84,7 +84,7 @@ public class DefaultMemberService implements MemberService {
 
     @Transactional(readOnly = true)
     @Override
-    public CheckDuplicateEmailResponse isDuplicateEmail(String email) {
+    public CheckDuplicateEmailResponse checkDuplicateEmail(String email) {
         return new CheckDuplicateEmailResponse(memberRepository.existsByEmail(email));
     }
 
@@ -101,7 +101,7 @@ public class DefaultMemberService implements MemberService {
 
 
     // 추후 중복 검사가 필요한 필드가 늘어날 경우 확장해야함
-    private void checkDuplicateEmail(String email) {
+    private void validateEmailUniqueness(String email) {
         if (memberRepository.existsByEmail(email)) {
             throw new DuplicateEmailException(ErrorMessages.DUPLICATE_EMAIL_EXCEPTION_MESSAGE);
         }

--- a/src/main/java/com/parksupark/soomjae/server/member/service/MemberService.java
+++ b/src/main/java/com/parksupark/soomjae/server/member/service/MemberService.java
@@ -16,6 +16,6 @@ public interface MemberService {
 
     MemberResponse updateNickname(Long id, String nickname);
 
-    CheckDuplicateEmailResponse isDuplicateEmail(String email);
+    CheckDuplicateEmailResponse checkDuplicateEmail(String email);
 
 }

--- a/src/main/java/com/parksupark/soomjae/server/member/service/MemberService.java
+++ b/src/main/java/com/parksupark/soomjae/server/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.parksupark.soomjae.server.member.service;
 
+import com.parksupark.soomjae.server.member.dto.CheckDuplicateEmailResponse;
 import com.parksupark.soomjae.server.member.dto.CreateMemberRequest;
 import com.parksupark.soomjae.server.member.dto.MemberResponse;
 
@@ -14,5 +15,7 @@ public interface MemberService {
     MemberResponse updatePassword(Long id, String password);
 
     MemberResponse updateNickname(Long id, String nickname);
+
+    CheckDuplicateEmailResponse isDuplicateEmail(String email);
 
 }

--- a/src/test/java/com/parksupark/soomjae/server/member/MemberE2ETest.java
+++ b/src/test/java/com/parksupark/soomjae/server/member/MemberE2ETest.java
@@ -11,10 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.parksupark.soomjae.server.auth.common.jwt.JwtGenerator;
-import com.parksupark.soomjae.server.member.dto.CreateMemberRequest;
-import com.parksupark.soomjae.server.member.dto.MemberResponse;
-import com.parksupark.soomjae.server.member.dto.PatchEmailRequest;
-import com.parksupark.soomjae.server.member.dto.PatchNicknameRequest;
+import com.parksupark.soomjae.server.member.dto.*;
 import com.parksupark.soomjae.server.member.entity.Member;
 import com.parksupark.soomjae.server.member.exception.DuplicateEmailException;
 import com.parksupark.soomjae.server.member.exception.MemberNotFoundException;
@@ -65,6 +62,7 @@ class MemberE2ETest {
     private static final String GET_MEMBER_INFO_URI = "/v1/members/{memberId}";
     private static final String PATCH_MEMBER_EMAIL_URI = "/v1/members/me/update-email";
     private static final String PATCH_MEMBER_NICKNAME_URI = "/v1/members/me/update-nickname";
+    private static final String CHECK_DUPLICATE_EMAIL_URI = "/v1/members/check-duplicate-email";
 
     // === HTTP 헤더 상수
     private static final String HEADER_AUTHORIZATION = "Authorization";
@@ -281,7 +279,7 @@ class MemberE2ETest {
         // 요청 바디 생성
         final String newNickname = "newnickname";
         PatchNicknameRequest patchNicknameRequest = new PatchNicknameRequest(newNickname);
-        
+
         // when + then
         mockMvc.perform(patch(PATCH_MEMBER_NICKNAME_URI)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -291,6 +289,42 @@ class MemberE2ETest {
             .andDo(print())
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.nickname").value(newNickname));
+    }
+
+    @Test
+    @DisplayName("중복된 이메일로 isDuplicateEmail 호출시 true 반환")
+    void isDuplicateEmailWithExistsEmail_shouldReturnTrue() throws Exception {
+        // given
+        saveMember();
+
+        // 요청 바디 생성
+        CheckDuplicateEmailRequest request = new CheckDuplicateEmailRequest(email);
+
+        // when + then
+        mockMvc.perform(post(CHECK_DUPLICATE_EMAIL_URI)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.duplicate").value(true));
+    }
+
+    @Test
+    @DisplayName("중복되지 않은 이메일로 isDuplicateEmail 호출시 false 반환")
+    void isDuplicateEmailWithNonExistsEmail_shouldReturnFalse() throws Exception {
+        // given
+        saveMember();
+
+        // 요청 바디 생성
+        CheckDuplicateEmailRequest request = new CheckDuplicateEmailRequest("newEmail@example.com");
+
+        // when + then
+        mockMvc.perform(post(CHECK_DUPLICATE_EMAIL_URI)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.duplicate").value(false));
     }
 
     private String createJwt(Member member) {

--- a/src/test/java/com/parksupark/soomjae/server/member/service/DefaultMemberServiceUnitTest.java
+++ b/src/test/java/com/parksupark/soomjae/server/member/service/DefaultMemberServiceUnitTest.java
@@ -145,12 +145,12 @@ class DefaultMemberServiceUnitTest {
 
     @Test
     @DisplayName("이미 가입된 이메일을 중복 검사하면 true를 반환한다")
-    void isDuplicateEmailWithExistsEmail_shouldReturnTrue() {
+    void checkDuplicateEmailWithExistsEmail_shouldReturnTrue() {
         // given
         saveMember();
 
         // when
-        CheckDuplicateEmailResponse response = memberService.isDuplicateEmail(email);
+        CheckDuplicateEmailResponse response = memberService.checkDuplicateEmail(email);
 
         // then
         assertThat(response.isDuplicate()).isTrue();
@@ -158,9 +158,9 @@ class DefaultMemberServiceUnitTest {
 
     @Test
     @DisplayName("이메일 중복 검사시 중복되지 않았다면 false를 반환한다")
-    void isDuplicateEmailWithNonExistsEmail_shouldReturnFalse() {
+    void checkDuplicateEmailWithNonExistsEmail_shouldReturnFalse() {
         // when
-        CheckDuplicateEmailResponse response = memberService.isDuplicateEmail(email);
+        CheckDuplicateEmailResponse response = memberService.checkDuplicateEmail(email);
 
         // then
         assertThat(response.isDuplicate()).isFalse();

--- a/src/test/java/com/parksupark/soomjae/server/member/service/DefaultMemberServiceUnitTest.java
+++ b/src/test/java/com/parksupark/soomjae/server/member/service/DefaultMemberServiceUnitTest.java
@@ -1,7 +1,9 @@
 package com.parksupark.soomjae.server.member.service;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.parksupark.soomjae.server.member.dto.CheckDuplicateEmailResponse;
 import com.parksupark.soomjae.server.member.dto.CreateMemberRequest;
 import com.parksupark.soomjae.server.member.dto.MemberResponse;
 import com.parksupark.soomjae.server.member.entity.Member;
@@ -10,6 +12,7 @@ import com.parksupark.soomjae.server.member.exception.MemberNotFoundException;
 import com.parksupark.soomjae.server.member.repository.JpaLikeInMemoryMemberRepository;
 import com.parksupark.soomjae.server.member.repository.MemberRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -140,9 +143,32 @@ class DefaultMemberServiceUnitTest {
             () -> memberService.updatePassword(-1L, "dummy"));
     }
 
+    @Test
+    @DisplayName("이미 가입된 이메일을 중복 검사하면 true를 반환한다")
+    void isDuplicateEmailWithExistsEmail_shouldReturnTrue() {
+        // given
+        saveMember();
+
+        // when
+        CheckDuplicateEmailResponse response = memberService.isDuplicateEmail(email);
+
+        // then
+        assertThat(response.isDuplicate()).isTrue();
+    }
+
+    @Test
+    @DisplayName("이메일 중복 검사시 중복되지 않았다면 false를 반환한다")
+    void isDuplicateEmailWithNonExistsEmail_shouldReturnFalse() {
+        // when
+        CheckDuplicateEmailResponse response = memberService.isDuplicateEmail(email);
+
+        // then
+        assertThat(response.isDuplicate()).isFalse();
+    }
+
     private Member saveMember() {
         return memberRepository.save(
-            Member.create(email, passwordEncoder.encode(password), nickname));
+                Member.create(email, passwordEncoder.encode(password), nickname));
     }
 
 }

--- a/src/test/java/com/parksupark/soomjae/server/member/service/NoOpMemberService.java
+++ b/src/test/java/com/parksupark/soomjae/server/member/service/NoOpMemberService.java
@@ -32,7 +32,7 @@ public class NoOpMemberService implements MemberService {
     }
 
     @Override
-    public CheckDuplicateEmailResponse isDuplicateEmail(String email) {
+    public CheckDuplicateEmailResponse checkDuplicateEmail(String email) {
         return null;
     }
 }

--- a/src/test/java/com/parksupark/soomjae/server/member/service/NoOpMemberService.java
+++ b/src/test/java/com/parksupark/soomjae/server/member/service/NoOpMemberService.java
@@ -1,5 +1,6 @@
 package com.parksupark.soomjae.server.member.service;
 
+import com.parksupark.soomjae.server.member.dto.CheckDuplicateEmailResponse;
 import com.parksupark.soomjae.server.member.dto.CreateMemberRequest;
 import com.parksupark.soomjae.server.member.dto.MemberResponse;
 
@@ -27,6 +28,11 @@ public class NoOpMemberService implements MemberService {
 
     @Override
     public MemberResponse createMember(CreateMemberRequest request) {
+        return null;
+    }
+
+    @Override
+    public CheckDuplicateEmailResponse isDuplicateEmail(String email) {
         return null;
     }
 }

--- a/src/test/resources/application-test2.properties
+++ b/src/test/resources/application-test2.properties
@@ -1,5 +1,5 @@
 # H2 in-memory DB 설정
-spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE?serverTimezone=UTC
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,5 +1,5 @@
 # H2 in-memory DB 설정
-spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE?serverTimezone=UTC
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=


### PR DESCRIPTION
## ✅ PR 체크리스트
- [x] Assignee를 지정했나요?
- [x] 병합 브랜치를 확인했나요?
- [x] 관련 이슈를 연결했나요?
- [x] 로컬 빌드에 성공했나요?

## 📝 변경 내용
- 이메일 중복 체크 API를 추가하고 해당 기능에 대한 테스트 코드를 작성하였습니다.
- CheckEmailDuplicateResponse 응답 dto는 duplicate 라는 boolean 타입의 필드값을 가지며 중복시에 true, 그렇지 않은 경우 false를 포함합니다. 응답 데이터 형식에 수정이 필요하신 경우 issue 주시면 바로 수정하겠습니다.

## 📎 관련 이슈
- close #66 