### PR TITLE
fix: Like 여부 확인 API 로그인 하지 않았을시 false 응답하도록 분기 처리

### DIFF
--- a/src/main/java/com/parksupark/soomjae/server/community/like/service/DefaultLikeService.java
+++ b/src/main/java/com/parksupark/soomjae/server/community/like/service/DefaultLikeService.java
@@ -76,9 +76,10 @@ public class DefaultLikeService implements LikeService {
 
         Long likeCount = likeRepository.countByPostTypeAndPostId(postType, postId);
 
-        Boolean liked = likeRepository.existsByPostTypeAndPostIdAndMemberId(postType,
-                postId, userDetails.getMember()
-                        .getId());
+        boolean liked =
+            userDetails != null && likeRepository.existsByPostTypeAndPostIdAndMemberId(postType,
+                postId,
+                userDetails.getMember().getId());
 
         return new LikeStatusResponse(liked, likeCount);
     }


### PR DESCRIPTION
## ✅ PR 체크리스트
- [ ] Assignee를 지정했나요?
- [ ] 병합 브랜치를 확인했나요?
- [ ] 관련 이슈를 연결했나요?
- [ ] 로컬 빌드에 성공했나요?

## 📝 변경 내용
- Service에서 userDetails가 null 일시 false 응답하도록 수정했습니다.

## 📎 관련 이슈
- close 