### PR TITLE
feat: 이메일 인증 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.4'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
 
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/parksupark/soomjae/server/SoomjaeBackApplication.java
+++ b/src/main/java/com/parksupark/soomjae/server/SoomjaeBackApplication.java
@@ -2,7 +2,9 @@ package com.parksupark.soomjae.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @SpringBootApplication
 public class SoomjaeBackApplication {
 

--- a/src/main/java/com/parksupark/soomjae/server/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/parksupark/soomjae/server/auth/jwt/JwtProvider.java
@@ -29,7 +29,6 @@ public class JwtProvider {
     private final AccessTokenParser accessTokenParser;
     private final RefreshTokenParser refreshTokenParser;
 
-
     public String generateAccessToken(String subject, Map<String, Object> claims) {
         return accessTokenGenerator.generate(subject, claims);
     }

--- a/src/main/java/com/parksupark/soomjae/server/common/constant/ValidationMessages.java
+++ b/src/main/java/com/parksupark/soomjae/server/common/constant/ValidationMessages.java
@@ -11,6 +11,10 @@ public class ValidationMessages {
     // 이메일
     public static final String EMAIL_INVALID_FORMAT = "올바른 이메일 형식이 아닙니다.";
 
+    // 이메일 인증 코드
+    public static final String VERIFICATION_CODE_INVALID_FORMAT = "인증코드는 6자리 영문자와 숫자로만 구성되어야 합니다";
+
+
     private ValidationMessages() {
 
     }

--- a/src/main/java/com/parksupark/soomjae/server/common/exception/ErrorMessages.java
+++ b/src/main/java/com/parksupark/soomjae/server/common/exception/ErrorMessages.java
@@ -31,7 +31,8 @@ public class ErrorMessages {
     public static final String OAUTH2_GOOGLE_ID_TOKEN_VERIFICATION_FAILED_MESSAGE =
         "Google Id Token 검증 실패";
 
-    public static final String EMAIL_VERIFICATION_NOT_FOUND_MESSAGE = "이메일 인증 정보를 찾을 수 없습니다.(잘못된 이메일 혹은 잘못된 인증 코드)";
+    public static final String EMAIL_VERIFICATION_NOT_FOUND_MESSAGE =
+        "이메일 인증 정보를 찾을 수 없습니다.(잘못된 이메일 혹은 잘못된 인증 코드)";
     public static final String EMAIL_NOT_VERIFIED_MESSAGE = "인증되지 않은 이메일로는 회원가입 할 수 없습니다.";
     public static final String EMAIL_SEND_FAILED_MESSAGE = "인증코드 이메일 발송에 실패했습니다.";
     

--- a/src/main/java/com/parksupark/soomjae/server/common/exception/ErrorMessages.java
+++ b/src/main/java/com/parksupark/soomjae/server/common/exception/ErrorMessages.java
@@ -31,8 +31,7 @@ public class ErrorMessages {
     public static final String OAUTH2_GOOGLE_ID_TOKEN_VERIFICATION_FAILED_MESSAGE =
         "Google Id Token 검증 실패";
 
-    public static final String EMAIL_VERIFICATION_NOT_FOUND_MESSAGE = "이메일 인증 정보를 찾을 수 없습니다.";
-    public static final String EMAIL_VERIFICATION_WRONG_CODE_MESSAGE = "잘못된 인증 코드입니다.";
+    public static final String EMAIL_VERIFICATION_NOT_FOUND_MESSAGE = "이메일 인증 정보를 찾을 수 없습니다.(잘못된 이메일 혹은 잘못된 인증 코드)";
     public static final String EMAIL_NOT_VERIFIED_MESSAGE = "인증되지 않은 이메일로는 회원가입 할 수 없습니다.";
     public static final String EMAIL_SEND_FAILED_MESSAGE = "인증코드 이메일 발송에 실패했습니다.";
     

--- a/src/main/java/com/parksupark/soomjae/server/common/exception/ErrorMessages.java
+++ b/src/main/java/com/parksupark/soomjae/server/common/exception/ErrorMessages.java
@@ -32,7 +32,6 @@ public class ErrorMessages {
         "Google Id Token 검증 실패";
 
     public static final String EMAIL_VERIFICATION_NOT_FOUND_MESSAGE = "이메일 인증 정보를 찾을 수 없습니다.";
-    public static final String EMAIL_VERIFICATION_EXPIRED_MESSAGE = "만료된 이메일 인증 정보입니다.";
     public static final String EMAIL_VERIFICATION_WRONG_CODE_MESSAGE = "잘못된 인증 코드입니다.";
     public static final String EMAIL_NOT_VERIFIED_MESSAGE = "인증되지 않은 이메일로는 회원가입 할 수 없습니다.";
     public static final String EMAIL_SEND_FAILED_MESSAGE = "인증코드 이메일 발송에 실패했습니다.";

--- a/src/main/java/com/parksupark/soomjae/server/common/exception/ErrorMessages.java
+++ b/src/main/java/com/parksupark/soomjae/server/common/exception/ErrorMessages.java
@@ -26,6 +26,12 @@ public class ErrorMessages {
 
     public static final String OAUTH2_EMAIL_NOT_VERIFIED_MESSAGE = "이메일이 인증되지 않았습니다.";
     public static final String OAUTH2_PROVIDER_NOT_SUPPORT_MESSAGE = "지원하지 않는 OAuth Provider: ";
+
+    public static final String EMAIL_VERIFICATION_NOT_FOUND_MESSAGE = "이메일 인증 정보를 찾을 수 없습니다.";
+    public static final String EMAIL_VERIFICATION_EXPIRED_MESSAGE = "만료된 이메일 인증 정보입니다.";
+    public static final String EMAIL_VERIFICATION_WRONG_CODE_MESSAGE = "잘못된 인증 코드입니다.";
+    public static final String EMAIL_NOT_VERIFIED_MESSAGE = "인증되지 않은 이메일로는 회원가입 할 수 없습니다.";
+    public static final String EMAIL_SEND_FAILED_MESSAGE = "인증코드 이메일 발송에 실패했습니다.";
     
     private ErrorMessages() {
     }

--- a/src/main/java/com/parksupark/soomjae/server/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/parksupark/soomjae/server/common/exception/GlobalExceptionHandler.java
@@ -8,11 +8,11 @@ import com.parksupark.soomjae.server.community.common.exception.AlreadyLikedExce
 import com.parksupark.soomjae.server.community.common.exception.InvalidPostIdException;
 import com.parksupark.soomjae.server.community.common.exception.InvalidPostTypeException;
 import com.parksupark.soomjae.server.community.common.exception.LikeNotFoundException;
-import com.parksupark.soomjae.server.email.exception.EmailVerificationExpiredException;
 import com.parksupark.soomjae.server.email.exception.EmailVerificationFailedException;
 import com.parksupark.soomjae.server.member.exception.DuplicateEmailException;
 import com.parksupark.soomjae.server.member.exception.MemberNotFoundException;
 import java.util.List;
+import org.apache.coyote.BadRequestException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -32,8 +32,8 @@ public class GlobalExceptionHandler {
     // 어떠한 Exception 발생하더라도 동작이 같다면 굳이 나눌 필요는 없어보이긴 함
     @ExceptionHandler({InvalidPostTypeException.class, InvalidPostIdException.class,
         LikeNotFoundException.class, AlreadyLikedException.class, MemberNotFoundException.class,
-        DuplicateEmailException.class, EmailVerificationExpiredException.class,
-        EmailVerificationFailedException.class, ResourceNotFoundException.class})
+        DuplicateEmailException.class, EmailVerificationFailedException.class,
+        ResourceNotFoundException.class})
     protected ResponseEntity<String> handleBadRequestException(
         RuntimeException e) {
         return ResponseEntity.status(400).body(e.getMessage());

--- a/src/main/java/com/parksupark/soomjae/server/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/parksupark/soomjae/server/common/exception/GlobalExceptionHandler.java
@@ -8,6 +8,8 @@ import com.parksupark.soomjae.server.community.common.exception.AlreadyLikedExce
 import com.parksupark.soomjae.server.community.common.exception.InvalidPostIdException;
 import com.parksupark.soomjae.server.community.common.exception.InvalidPostTypeException;
 import com.parksupark.soomjae.server.community.common.exception.LikeNotFoundException;
+import com.parksupark.soomjae.server.email.exception.EmailVerificationExpiredException;
+import com.parksupark.soomjae.server.email.exception.EmailVerificationFailedException;
 import com.parksupark.soomjae.server.member.exception.DuplicateEmailException;
 import com.parksupark.soomjae.server.member.exception.MemberNotFoundException;
 import java.util.List;
@@ -30,10 +32,10 @@ public class GlobalExceptionHandler {
     // 어떠한 Exception 발생하더라도 동작이 같다면 굳이 나눌 필요는 없어보이긴 함
     @ExceptionHandler({InvalidPostTypeException.class, InvalidPostIdException.class,
         LikeNotFoundException.class, AlreadyLikedException.class, MemberNotFoundException.class,
-        DuplicateEmailException.class})
-    protected ResponseEntity<String> handleInvalidPostTypeException(
+        DuplicateEmailException.class, EmailVerificationExpiredException.class,
+        EmailVerificationFailedException.class, ResourceNotFoundException.class})
+    protected ResponseEntity<String> handleBadRequestException(
         RuntimeException e) {
-
         return ResponseEntity.status(400).body(e.getMessage());
     }
 
@@ -79,5 +81,4 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(400)
             .body(e.getMessage());
     }
-
 }

--- a/src/main/java/com/parksupark/soomjae/server/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/parksupark/soomjae/server/common/exception/GlobalExceptionHandler.java
@@ -8,11 +8,9 @@ import com.parksupark.soomjae.server.community.common.exception.AlreadyLikedExce
 import com.parksupark.soomjae.server.community.common.exception.InvalidPostIdException;
 import com.parksupark.soomjae.server.community.common.exception.InvalidPostTypeException;
 import com.parksupark.soomjae.server.community.common.exception.LikeNotFoundException;
-import com.parksupark.soomjae.server.email.exception.EmailVerificationFailedException;
 import com.parksupark.soomjae.server.member.exception.DuplicateEmailException;
 import com.parksupark.soomjae.server.member.exception.MemberNotFoundException;
 import java.util.List;
-import org.apache.coyote.BadRequestException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -32,8 +30,7 @@ public class GlobalExceptionHandler {
     // 어떠한 Exception 발생하더라도 동작이 같다면 굳이 나눌 필요는 없어보이긴 함
     @ExceptionHandler({InvalidPostTypeException.class, InvalidPostIdException.class,
         LikeNotFoundException.class, AlreadyLikedException.class, MemberNotFoundException.class,
-        DuplicateEmailException.class, EmailVerificationFailedException.class,
-        ResourceNotFoundException.class})
+        DuplicateEmailException.class, ResourceNotFoundException.class})
     protected ResponseEntity<String> handleBadRequestException(
         RuntimeException e) {
         return ResponseEntity.status(400).body(e.getMessage());

--- a/src/main/java/com/parksupark/soomjae/server/community/post/meetingpost/service/MeetingPostService.java
+++ b/src/main/java/com/parksupark/soomjae/server/community/post/meetingpost/service/MeetingPostService.java
@@ -209,6 +209,6 @@ public class MeetingPostService {
     public ParticipantListResponse findAllParticipantsByPostId(Long postId) {
         return ParticipantListResponse.of(
             participationRepository.findByMeetingPostId(postId).stream()
-                .map(participation -> MemberResponse.of(participation.getParticipant())).toList());
+                .map(participation -> MemberResponse.create(participation.getParticipant())).toList());
     }
 }

--- a/src/main/java/com/parksupark/soomjae/server/community/post/meetingpost/service/MeetingPostService.java
+++ b/src/main/java/com/parksupark/soomjae/server/community/post/meetingpost/service/MeetingPostService.java
@@ -209,6 +209,7 @@ public class MeetingPostService {
     public ParticipantListResponse findAllParticipantsByPostId(Long postId) {
         return ParticipantListResponse.of(
             participationRepository.findByMeetingPostId(postId).stream()
-                .map(participation -> MemberResponse.create(participation.getParticipant())).toList());
+                .map(participation -> MemberResponse.create(participation.getParticipant()))
+                .toList());
     }
 }

--- a/src/main/java/com/parksupark/soomjae/server/email/controller/EmailVerificationController.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/controller/EmailVerificationController.java
@@ -1,0 +1,92 @@
+package com.parksupark.soomjae.server.email.controller;
+
+import com.parksupark.soomjae.server.email.dto.SendCodeRequest;
+import com.parksupark.soomjae.server.email.dto.VerifyCodeRequest;
+import com.parksupark.soomjae.server.email.service.EmailVerificationService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/mail")
+public class EmailVerificationController {
+
+    private final EmailVerificationService emailVerificationService;
+
+
+    /**
+     * 이메일 인증코드 발송
+     * <p>
+     * <b>플로우:</b>
+     * <ol>
+     *   <li>영문자와 숫자가 조합된 6자리 랜덤 코드 생성</li>
+     *   <li>EmailVerification 엔티티를 생성하여 DB에 저장 (만료시간: 5분)</li>
+     *   <li>HTML 템플릿을 사용하여 이메일 작성</li>
+     *   <li>Gmail SMTP를 통해 이메일 발송</li>
+     * </ol>
+     *
+     * <b>참고사항:</b>
+     * <ul>
+     *   <li>동일한 이메일로 재요청 시 기존 코드는 새 코드로 덮어씌워집니다</li>
+     *   <li>생성된 EmailVerification 의 유효기간은 5분입니다</li>
+     * </ul>
+     *
+     * @param request 이메일 주소가 포함된 요청 객체
+     * @return 발송 완료 응답 (HTTP 200)
+     *
+     * @throws jakarta.validation.ConstraintViolationException 유효하지 않은 이메일 형식일 경우
+     * @throws com.parksupark.soomjae.server.email.exception.EmailVerificationFailedException 이메일 발송 실패 시
+     *
+     * @see com.parksupark.soomjae.server.email.service.DefaultEmailVerificationService#sendVerificationCode(String)
+     */
+    @PostMapping("/send-code")
+    public ResponseEntity<Void> sendVerificationCode(@RequestBody @Valid SendCodeRequest request) {
+        emailVerificationService.sendVerificationCode(request.getEmail());
+
+        return ResponseEntity.ok().build();
+    }
+
+
+    /**
+     * 이메일 인증코드 검증
+     * <p>
+     * <b>플로우:</b>
+     * <ol>
+     *   <li>이메일로 EmailVerification 엔티티 조회</li>
+     *   <li>코드 만료 시간 검증 (만료 시 삭제)</li>
+     *   <li>입력된 코드와 저장된 코드 비교 검증</li>
+     *   <li>검증 성공 시 isVerified를 true로 설정</li>
+     *   <li>회원가입 프로세스에서 이메일 인증 완료 상태로 사용 가능</li>
+     * </ol>
+     *
+     * <b>검증 규칙:</b>
+     * <ul>
+     *   <li>코드는 대소문자 구분 없이 검증됩니다 (자동으로 대문자 변환)</li>
+     *   <li>코드 앞뒤 공백은 자동으로 제거됩니다</li>
+     *   <li>만료된 인증 요청은 해당 요청 발생 시 DB에서 삭제됩니다 (TODO: Redis 사용하여 자동 삭제)</li>
+     * </ul>
+     *
+     * @param request 이메일 주소와 인증코드가 포함된 요청 객체
+     * @return 인증 성공 메시지 (HTTP 200)
+     *
+     * @throws jakarta.validation.ConstraintViolationException 요청 파라미터 유효성 검증 실패 시
+     * @throws com.parksupark.soomjae.server.common.exception.ResourceNotFoundException 해당 이메일의 EmailVerification 을 찾을 수 없을 경우
+     * @throws com.parksupark.soomjae.server.email.exception.EmailVerificationExpiredException 인증코드가 만료된 경우
+     * @throws com.parksupark.soomjae.server.email.exception.EmailVerificationFailedException 인증코드가 일치하지 않을 경우
+     *
+     * @see com.parksupark.soomjae.server.email.service.DefaultEmailVerificationService#verifyCode(String, String)
+     */
+    @PostMapping("/verify-code")
+    public ResponseEntity<String> verifyCode(@RequestBody @Valid VerifyCodeRequest request) {
+        String email = request.getEmail();
+        String code = request.getCode();
+
+        emailVerificationService.verifyCode(email, code);
+        return ResponseEntity.ok("인증 성공");
+    }
+}

--- a/src/main/java/com/parksupark/soomjae/server/email/controller/EmailVerificationController.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/controller/EmailVerificationController.java
@@ -16,7 +16,6 @@ public class EmailVerificationController {
 
     private final EmailVerificationService emailVerificationService;
 
-
     /**
      * 이메일 인증코드 발송
      *
@@ -37,18 +36,16 @@ public class EmailVerificationController {
      * @param request 이메일 주소가 포함된 요청 객체
      * @return 발송 완료 응답 (HTTP 200)
      * @throws jakarta.validation.ConstraintViolationException
-     *  유효하지 않은 이메일 형식일 경우
+     * 유효하지 않은 이메일 형식일 경우
      * @throws com.parksupark.soomjae.server.email.exception.EmailVerificationFailedException
      * 이메일 발송 실패 시
-     * @see com.parksupark.soomjae.server.email.service.DefaultEmailVerificationService
-     * #sendVerificationCode(String)
+     * @see com.parksupark.soomjae.server.email.service.DefaultEmailVerificationService#sendVerificationCode(String)
      */
     @PostMapping("/verification")
     public DeferredResult<ResponseEntity<?>> sendVerificationCode(
         @RequestBody @Valid SendCodeRequest request) {
         return emailVerificationService.sendVerificationCode(request.getEmail());
     }
-
 
     /**
      * 이메일 인증코드 검증
@@ -70,11 +67,11 @@ public class EmailVerificationController {
      *
      * @param request 이메일 주소와 인증코드가 포함된 요청 객체
      * @return 인증 성공 메시지 (HTTP 200)
-     * @throws jakarta.validation.ConstraintViolationException 요청 파라미터 유효성 검증 실패 시
+     * @throws jakarta.validation.ConstraintViolationException
+     * 요청 파라미터 유효성 검증 실패 시
      * @throws com.parksupark.soomjae.server.common.exception.ResourceNotFoundException
      * 이메일과 코드를 사용한 EmailVerification 조회결과가 없을 경우
-     * @see com.parksupark.soomjae.server.email.service.DefaultEmailVerificationService
-     * #verifyCode(String, String)
+     * @see com.parksupark.soomjae.server.email.service.DefaultEmailVerificationService#verifyCode(String, String)
      */
     @PutMapping("/verification")
     public ResponseEntity<String> verifyCode(@RequestBody @Valid VerifyCodeRequest request) {

--- a/src/main/java/com/parksupark/soomjae/server/email/controller/EmailVerificationController.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/controller/EmailVerificationController.java
@@ -6,14 +6,11 @@ import com.parksupark.soomjae.server.email.service.EmailVerificationService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/v1/mail")
+@RequestMapping("/v1/email")
 public class EmailVerificationController {
 
     private final EmailVerificationService emailVerificationService;
@@ -44,7 +41,7 @@ public class EmailVerificationController {
      *
      * @see com.parksupark.soomjae.server.email.service.DefaultEmailVerificationService#sendVerificationCode(String)
      */
-    @PostMapping("/send-code")
+    @PostMapping("/verification")
     public ResponseEntity<Void> sendVerificationCode(@RequestBody @Valid SendCodeRequest request) {
         emailVerificationService.sendVerificationCode(request.getEmail());
 
@@ -80,7 +77,7 @@ public class EmailVerificationController {
      *
      * @see com.parksupark.soomjae.server.email.service.DefaultEmailVerificationService#verifyCode(String, String)
      */
-    @PostMapping("/verify-code")
+    @PutMapping("/verification")
     public ResponseEntity<String> verifyCode(@RequestBody @Valid VerifyCodeRequest request) {
         String email = request.getEmail();
         String code = request.getCode();

--- a/src/main/java/com/parksupark/soomjae/server/email/controller/EmailVerificationController.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/controller/EmailVerificationController.java
@@ -3,13 +3,11 @@ package com.parksupark.soomjae.server.email.controller;
 import com.parksupark.soomjae.server.email.dto.SendCodeRequest;
 import com.parksupark.soomjae.server.email.dto.VerifyCodeRequest;
 import com.parksupark.soomjae.server.email.service.EmailVerificationService;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.request.async.DeferredResult;
-import org.springframework.web.filter.ShallowEtagHeaderFilter;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,25 +19,27 @@ public class EmailVerificationController {
 
     /**
      * 이메일 인증코드 발송
-     * <p>
-     * <b>플로우:</b>
+     *
+     * <p><b>플로우:</b>
      * <ol>
-     *   <li>영문자와 숫자가 조합된 6자리 랜덤 코드 생성</li>
-     *   <li>EmailVerification 엔티티를 생성하여 DB에 저장 (만료시간: 5분)</li>
-     *   <li>HTML 템플릿을 사용하여 이메일 작성</li>
-     *   <li>Gmail SMTP를 통해 이메일 발송</li>
+     * <li>영문자와 숫자가 조합된 6자리 랜덤 코드 생성</li>
+     * <li>EmailVerification 엔티티를 생성하여 DB에 저장 (만료시간: 5분)</li>
+     * <li>HTML 템플릿을 사용하여 이메일 작성</li>
+     * <li>Gmail SMTP를 통해 이메일 발송</li>
      * </ol>
      *
-     * <b>참고사항:</b>
+     * <p><b>참고사항:</b>
      * <ul>
-     *   <li>동일한 이메일로 재요청 시 기존 코드는 새 코드로 덮어씌워집니다</li>
-     *   <li>생성된 EmailVerification 의 유효기간은 5분입니다</li>
+     * <li>동일한 이메일로 재요청 시 기존 코드는 새 코드로 덮어씌워집니다</li>
+     * <li>생성된 EmailVerification 의 유효기간은 5분입니다</li>
      * </ul>
      *
      * @param request 이메일 주소가 포함된 요청 객체
      * @return 발송 완료 응답 (HTTP 200)
-     * @throws jakarta.validation.ConstraintViolationException 유효하지 않은 이메일 형식일 경우
-     * @throws com.parksupark.soomjae.server.email.exception.EmailVerificationFailedException 이메일 발송 실패 시
+     * @throws jakarta.validation.ConstraintViolationException
+     * 유효하지 않은 이메일 형식일 경우
+     * @throws com.parksupark.soomjae.server.email.exception.EmailVerificationFailedException
+     * 이메일 발송 실패 시
      * @see com.parksupark.soomjae.server.email.service.DefaultEmailVerificationService#sendVerificationCode(String)
      */
     @PostMapping("/verification")
@@ -51,28 +51,27 @@ public class EmailVerificationController {
 
     /**
      * 이메일 인증코드 검증
-     * <p>
-     * <b>플로우:</b>
+     *
+     * <p><b>플로우:</b>
      * <ol>
-     *   <li>이메일로 EmailVerification 엔티티 조회</li>
-     *   <li>코드 만료 시간 검증 (만료 시 삭제)</li>
-     *   <li>입력된 코드와 저장된 코드 비교 검증</li>
-     *   <li>검증 성공 시 isVerified를 true로 설정</li>
-     *   <li>회원가입 프로세스에서 이메일 인증 완료 상태로 사용 가능</li>
+     * <li>이메일로 EmailVerification 엔티티 조회</li>
+     * <li>코드 만료 시간 검증 (만료 시 삭제)</li>
+     * <li>입력된 코드와 저장된 코드 비교 검증</li>
+     * <li>검증 성공 시 isVerified를 true로 설정</li>
+     * <li>회원가입 프로세스에서 이메일 인증 완료 상태로 사용 가능</li>
      * </ol>
      *
-     * <b>검증 규칙:</b>
+     * <p><b>검증 규칙:</b>
      * <ul>
-     *   <li>코드는 대소문자 구분 없이 검증됩니다 (자동으로 대문자 변환)</li>
-     *   <li>코드 앞뒤 공백은 자동으로 제거됩니다</li>
+     * <li>코드는 대소문자 구분 없이 검증됩니다 (자동으로 대문자 변환)</li>
+     * <li>코드 앞뒤 공백은 자동으로 제거됩니다</li>
      * </ul>
      *
      * @param request 이메일 주소와 인증코드가 포함된 요청 객체
      * @return 인증 성공 메시지 (HTTP 200)
-     *
      * @throws jakarta.validation.ConstraintViolationException 요청 파라미터 유효성 검증 실패 시
-     * @throws com.parksupark.soomjae.server.common.exception.ResourceNotFoundException 이메일과 코드를 사용한 EmailVerification 조회결과가 없을 경우
-     *
+     * @throws com.parksupark.soomjae.server.common.exception.ResourceNotFoundException
+     * 이메일과 코드를 사용한 EmailVerification 조회결과가 없을 경우
      * @see com.parksupark.soomjae.server.email.service.DefaultEmailVerificationService#verifyCode(String, String)
      */
     @PutMapping("/verification")

--- a/src/main/java/com/parksupark/soomjae/server/email/controller/EmailVerificationController.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/controller/EmailVerificationController.java
@@ -7,6 +7,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.context.request.async.DeferredResult;
 
 @RestController
 @RequiredArgsConstructor
@@ -32,7 +33,7 @@ public class EmailVerificationController {
      *   <li>동일한 이메일로 재요청 시 기존 코드는 새 코드로 덮어씌워집니다</li>
      *   <li>생성된 EmailVerification 의 유효기간은 5분입니다</li>
      * </ul>
-     *
+     *6
      * @param request 이메일 주소가 포함된 요청 객체
      * @return 발송 완료 응답 (HTTP 200)
      *
@@ -42,10 +43,8 @@ public class EmailVerificationController {
      * @see com.parksupark.soomjae.server.email.service.DefaultEmailVerificationService#sendVerificationCode(String)
      */
     @PostMapping("/verification")
-    public ResponseEntity<Void> sendVerificationCode(@RequestBody @Valid SendCodeRequest request) {
-        emailVerificationService.sendVerificationCode(request.getEmail());
-
-        return ResponseEntity.ok().build();
+    public DeferredResult<ResponseEntity<Void>> sendVerificationCode(@RequestBody @Valid SendCodeRequest request) {
+        return emailVerificationService.sendVerificationCode(request.getEmail());
     }
 
 
@@ -65,15 +64,13 @@ public class EmailVerificationController {
      * <ul>
      *   <li>코드는 대소문자 구분 없이 검증됩니다 (자동으로 대문자 변환)</li>
      *   <li>코드 앞뒤 공백은 자동으로 제거됩니다</li>
-     *   <li>만료된 인증 요청은 해당 요청 발생 시 DB에서 삭제됩니다 (TODO: Redis 사용하여 자동 삭제)</li>
      * </ul>
      *
      * @param request 이메일 주소와 인증코드가 포함된 요청 객체
      * @return 인증 성공 메시지 (HTTP 200)
      *
      * @throws jakarta.validation.ConstraintViolationException 요청 파라미터 유효성 검증 실패 시
-     * @throws com.parksupark.soomjae.server.common.exception.ResourceNotFoundException 해당 이메일의 EmailVerification 을 찾을 수 없을 경우
-     * @throws com.parksupark.soomjae.server.email.exception.EmailVerificationFailedException 인증코드가 일치하지 않을 경우
+     * @throws com.parksupark.soomjae.server.common.exception.ResourceNotFoundException 이메일과 코드를 사용한 EmailVerification 조회결과가 없을 경우
      *
      * @see com.parksupark.soomjae.server.email.service.DefaultEmailVerificationService#verifyCode(String, String)
      */

--- a/src/main/java/com/parksupark/soomjae/server/email/controller/EmailVerificationController.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/controller/EmailVerificationController.java
@@ -19,27 +19,28 @@ public class EmailVerificationController {
     /**
      * 이메일 인증코드 발송
      *
-     * <p><b>플로우:</b>
+     * <p><b>플로우:</b></p>
      * <ol>
-     * <li>영문자와 숫자가 조합된 6자리 랜덤 코드 생성</li>
-     * <li>EmailVerification 엔티티를 생성하여 DB에 저장 (만료시간: 5분)</li>
-     * <li>HTML 템플릿을 사용하여 이메일 작성</li>
-     * <li>Gmail SMTP를 통해 이메일 발송</li>
+     *   <li>영문자와 숫자가 조합된 6자리 랜덤 코드 생성</li>
+     *   <li>EmailVerification 엔티티를 생성하여 DB에 저장 (만료시간: 5분)</li>
+     *   <li>HTML 템플릿을 사용하여 이메일 작성</li>
+     *   <li>Gmail SMTP를 통해 이메일 발송</li>
      * </ol>
      *
-     * <p><b>참고사항:</b>
+     * <p><b>참고사항:</b></p>
      * <ul>
-     * <li>동일한 이메일로 재요청 시 기존 코드는 새 코드로 덮어씌워집니다</li>
-     * <li>생성된 EmailVerification 의 유효기간은 5분입니다</li>
+     *   <li>동일한 이메일로 재요청 시 기존 코드는 새 코드로 덮어씌워집니다.</li>
+     *   <li>생성된 EmailVerification 의 유효기간은 5분입니다.</li>
      * </ul>
      *
      * @param request 이메일 주소가 포함된 요청 객체
      * @return 발송 완료 응답 (HTTP 200)
      * @throws jakarta.validation.ConstraintViolationException
-     * 유효하지 않은 이메일 형식일 경우
+     *         유효하지 않은 이메일 형식일 경우
      * @throws com.parksupark.soomjae.server.email.exception.EmailVerificationFailedException
-     * 이메일 발송 실패 시
-     * @see com.parksupark.soomjae.server.email.service.DefaultEmailVerificationService#sendVerificationCode(String)
+     *         이메일 발송 실패 시
+     * @see com.parksupark.soomjae.server.email.service.DefaultEmailVerificationService
+     *         #sendVerificationCode(String)
      */
     @PostMapping("/verification")
     public DeferredResult<ResponseEntity<?>> sendVerificationCode(
@@ -50,28 +51,29 @@ public class EmailVerificationController {
     /**
      * 이메일 인증코드 검증
      *
-     * <p><b>플로우:</b>
+     * <p><b>플로우:</b></p>
      * <ol>
-     * <li>이메일로 EmailVerification 엔티티 조회</li>
-     * <li>코드 만료 시간 검증 (만료 시 삭제)</li>
-     * <li>입력된 코드와 저장된 코드 비교 검증</li>
-     * <li>검증 성공 시 isVerified를 true로 설정</li>
-     * <li>회원가입 프로세스에서 이메일 인증 완료 상태로 사용 가능</li>
+     *   <li>이메일로 EmailVerification 엔티티 조회</li>
+     *   <li>코드 만료 시간 검증 (만료 시 삭제)</li>
+     *   <li>입력된 코드와 저장된 코드 비교 검증</li>
+     *   <li>검증 성공 시 isVerified를 true로 설정</li>
+     *   <li>회원가입 프로세스에서 이메일 인증 완료 상태로 사용 가능</li>
      * </ol>
      *
-     * <p><b>검증 규칙:</b>
+     * <p><b>검증 규칙:</b></p>
      * <ul>
-     * <li>코드는 대소문자 구분 없이 검증됩니다 (자동으로 대문자 변환)</li>
-     * <li>코드 앞뒤 공백은 자동으로 제거됩니다</li>
+     *   <li>코드는 대소문자 구분 없이 검증됩니다 (자동으로 대문자 변환)</li>
+     *   <li>코드 앞뒤 공백은 자동으로 제거됩니다</li>
      * </ul>
      *
      * @param request 이메일 주소와 인증코드가 포함된 요청 객체
      * @return 인증 성공 메시지 (HTTP 200)
      * @throws jakarta.validation.ConstraintViolationException
-     * 요청 파라미터 유효성 검증 실패 시
+     *         요청 파라미터 유효성 검증 실패 시
      * @throws com.parksupark.soomjae.server.common.exception.ResourceNotFoundException
-     * 이메일과 코드를 사용한 EmailVerification 조회결과가 없을 경우
-     * @see com.parksupark.soomjae.server.email.service.DefaultEmailVerificationService#verifyCode(String, String)
+     *         이메일과 코드를 사용한 EmailVerification 조회결과가 없을 경우
+     * @see com.parksupark.soomjae.server.email.service.DefaultEmailVerificationService
+     *         #verifyCode(String, String)
      */
     @PutMapping("/verification")
     public ResponseEntity<String> verifyCode(@RequestBody @Valid VerifyCodeRequest request) {

--- a/src/main/java/com/parksupark/soomjae/server/email/controller/EmailVerificationController.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/controller/EmailVerificationController.java
@@ -76,7 +76,6 @@ public class EmailVerificationController {
      *
      * @throws jakarta.validation.ConstraintViolationException 요청 파라미터 유효성 검증 실패 시
      * @throws com.parksupark.soomjae.server.common.exception.ResourceNotFoundException 해당 이메일의 EmailVerification 을 찾을 수 없을 경우
-     * @throws com.parksupark.soomjae.server.email.exception.EmailVerificationExpiredException 인증코드가 만료된 경우
      * @throws com.parksupark.soomjae.server.email.exception.EmailVerificationFailedException 인증코드가 일치하지 않을 경우
      *
      * @see com.parksupark.soomjae.server.email.service.DefaultEmailVerificationService#verifyCode(String, String)

--- a/src/main/java/com/parksupark/soomjae/server/email/controller/EmailVerificationController.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/controller/EmailVerificationController.java
@@ -37,7 +37,7 @@ public class EmailVerificationController {
      * @param request 이메일 주소가 포함된 요청 객체
      * @return 발송 완료 응답 (HTTP 200)
      * @throws jakarta.validation.ConstraintViolationException
-     * 유효하지 않은 이메일 형식일 경우
+     *  유효하지 않은 이메일 형식일 경우
      * @throws com.parksupark.soomjae.server.email.exception.EmailVerificationFailedException
      * 이메일 발송 실패 시
      * @see com.parksupark.soomjae.server.email.service.DefaultEmailVerificationService

--- a/src/main/java/com/parksupark/soomjae/server/email/controller/EmailVerificationController.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/controller/EmailVerificationController.java
@@ -40,7 +40,8 @@ public class EmailVerificationController {
      * 유효하지 않은 이메일 형식일 경우
      * @throws com.parksupark.soomjae.server.email.exception.EmailVerificationFailedException
      * 이메일 발송 실패 시
-     * @see com.parksupark.soomjae.server.email.service.DefaultEmailVerificationService#sendVerificationCode(String)
+     * @see com.parksupark.soomjae.server.email.service.DefaultEmailVerificationService
+     * #sendVerificationCode(String)
      */
     @PostMapping("/verification")
     public DeferredResult<ResponseEntity<?>> sendVerificationCode(
@@ -72,7 +73,8 @@ public class EmailVerificationController {
      * @throws jakarta.validation.ConstraintViolationException 요청 파라미터 유효성 검증 실패 시
      * @throws com.parksupark.soomjae.server.common.exception.ResourceNotFoundException
      * 이메일과 코드를 사용한 EmailVerification 조회결과가 없을 경우
-     * @see com.parksupark.soomjae.server.email.service.DefaultEmailVerificationService#verifyCode(String, String)
+     * @see com.parksupark.soomjae.server.email.service.DefaultEmailVerificationService
+     * #verifyCode(String, String)
      */
     @PutMapping("/verification")
     public ResponseEntity<String> verifyCode(@RequestBody @Valid VerifyCodeRequest request) {

--- a/src/main/java/com/parksupark/soomjae/server/email/controller/EmailVerificationController.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/controller/EmailVerificationController.java
@@ -3,11 +3,13 @@ package com.parksupark.soomjae.server.email.controller;
 import com.parksupark.soomjae.server.email.dto.SendCodeRequest;
 import com.parksupark.soomjae.server.email.dto.VerifyCodeRequest;
 import com.parksupark.soomjae.server.email.service.EmailVerificationService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.request.async.DeferredResult;
+import org.springframework.web.filter.ShallowEtagHeaderFilter;
 
 @RestController
 @RequiredArgsConstructor
@@ -33,17 +35,16 @@ public class EmailVerificationController {
      *   <li>동일한 이메일로 재요청 시 기존 코드는 새 코드로 덮어씌워집니다</li>
      *   <li>생성된 EmailVerification 의 유효기간은 5분입니다</li>
      * </ul>
-     *6
+     *
      * @param request 이메일 주소가 포함된 요청 객체
      * @return 발송 완료 응답 (HTTP 200)
-     *
      * @throws jakarta.validation.ConstraintViolationException 유효하지 않은 이메일 형식일 경우
      * @throws com.parksupark.soomjae.server.email.exception.EmailVerificationFailedException 이메일 발송 실패 시
-     *
      * @see com.parksupark.soomjae.server.email.service.DefaultEmailVerificationService#sendVerificationCode(String)
      */
     @PostMapping("/verification")
-    public DeferredResult<ResponseEntity<Void>> sendVerificationCode(@RequestBody @Valid SendCodeRequest request) {
+    public DeferredResult<ResponseEntity<?>> sendVerificationCode(
+        @RequestBody @Valid SendCodeRequest request) {
         return emailVerificationService.sendVerificationCode(request.getEmail());
     }
 

--- a/src/main/java/com/parksupark/soomjae/server/email/dto/SendCodeRequest.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/dto/SendCodeRequest.java
@@ -1,0 +1,21 @@
+package com.parksupark.soomjae.server.email.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Email;
+import lombok.Getter;
+
+@Getter
+public class SendCodeRequest {
+
+    @Email
+    private final String email;
+
+    @JsonCreator
+    public SendCodeRequest(
+        @JsonProperty("mail") String email
+    ) {
+        this.email = email;
+    }
+
+}

--- a/src/main/java/com/parksupark/soomjae/server/email/dto/SendCodeRequest.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/dto/SendCodeRequest.java
@@ -13,7 +13,7 @@ public class SendCodeRequest {
 
     @JsonCreator
     public SendCodeRequest(
-        @JsonProperty("mail") String email
+        @JsonProperty("email") String email
     ) {
         this.email = email;
     }

--- a/src/main/java/com/parksupark/soomjae/server/email/dto/VerifyCodeRequest.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/dto/VerifyCodeRequest.java
@@ -1,0 +1,31 @@
+package com.parksupark.soomjae.server.email.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.parksupark.soomjae.server.common.constant.ValidationMessages;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+
+@Getter
+public class VerifyCodeRequest {
+
+    @Email(message = ValidationMessages.EMAIL_INVALID_FORMAT)
+    @NotBlank(message = ValidationMessages.NOT_BLANK)
+    private final String email;
+
+    @NotBlank(message = ValidationMessages.NOT_BLANK)
+    @Pattern(regexp = "^[A-Za-z0-9]{6}$", message = "인증코드는 6자리 영문자와 숫자로만 구성되어야 합니다")
+    private final String code;
+
+    @JsonCreator
+    public VerifyCodeRequest(
+        @JsonProperty("email") String email,
+        @JsonProperty("code") String code
+    ) {
+        this.email = email;
+        this.code = code;
+    }
+
+}

--- a/src/main/java/com/parksupark/soomjae/server/email/entity/EmailVerification.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/entity/EmailVerification.java
@@ -13,15 +13,19 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class EmailVerification extends BaseEntity {
 
+    private static final int EMAIL_MAX_LENGTH = 255;
+    private static final int CODE_LENGTH = 6;
+    private static final int EXPIRATION_SECONDS = 300;
+
     @Id
-    @Column(length = 255)
+    @Column(length = EMAIL_MAX_LENGTH)
     private String email;
 
-    @Column(length = 6, nullable = false)
+    @Column(length = CODE_LENGTH, nullable = false)
     private String code;
 
     @Column(nullable = false)
-    private Instant expiredAt;
+    private Instant expirationTime;
 
     @Column(nullable = false, columnDefinition = "boolean default false")
     private boolean verified;
@@ -29,7 +33,7 @@ public class EmailVerification extends BaseEntity {
     private EmailVerification(String email, String code) {
         this.email = email;
         this.code = code;
-        this.expiredAt = Instant.now().plusSeconds(300);
+        this.expirationTime = Instant.now().plusSeconds(EXPIRATION_SECONDS);
     }
 
     public static EmailVerification create(String email, String code) {

--- a/src/main/java/com/parksupark/soomjae/server/email/entity/EmailVerification.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/entity/EmailVerification.java
@@ -3,7 +3,11 @@ package com.parksupark.soomjae.server.email.entity;
 import com.parksupark.soomjae.server.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
 import java.time.Instant;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,14 +15,22 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor
+@Table(indexes = {
+    @Index(name = "idx_email", columnList = "email"),
+    @Index(name = "idx_email_code_expiration", columnList = "email, code, expirationTime"),
+    @Index(name = "idx_email_verified_expiration", columnList = "email, verified, expirationTime")
+})
 public class EmailVerification extends BaseEntity {
 
     private static final int EMAIL_MAX_LENGTH = 255;
     private static final int CODE_LENGTH = 6;
-    private static final int EXPIRATION_SECONDS = 300;
+    private static final int EXPIRATION_SECONDS = 60 * 60;
 
     @Id
-    @Column(length = EMAIL_MAX_LENGTH)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = EMAIL_MAX_LENGTH, nullable = false)
     private String email;
 
     @Column(length = CODE_LENGTH, nullable = false)

--- a/src/main/java/com/parksupark/soomjae/server/email/entity/EmailVerification.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/entity/EmailVerification.java
@@ -1,0 +1,42 @@
+package com.parksupark.soomjae.server.email.entity;
+
+import com.parksupark.soomjae.server.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import java.time.Instant;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class EmailVerification extends BaseEntity {
+
+    @Id
+    @Column(length = 255)
+    private String email;
+
+    @Column(length = 6, nullable = false)
+    private String code;
+
+    @Column(nullable = false)
+    private Instant expiredAt;
+
+    @Column(nullable = false, columnDefinition = "boolean default false")
+    private boolean verified;
+
+    private EmailVerification(String email, String code) {
+        this.email = email;
+        this.code = code;
+        this.expiredAt = Instant.now().plusSeconds(300);
+    }
+
+    public static EmailVerification create(String email, String code) {
+        return new EmailVerification(email, code);
+    }
+
+    public void setVerified(boolean verified) {
+        this.verified = verified;
+    }
+}

--- a/src/main/java/com/parksupark/soomjae/server/email/exception/EmailVerificationExpiredException.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/exception/EmailVerificationExpiredException.java
@@ -1,0 +1,9 @@
+package com.parksupark.soomjae.server.email.exception;
+
+public class EmailVerificationExpiredException extends RuntimeException {
+
+    public EmailVerificationExpiredException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/parksupark/soomjae/server/email/exception/EmailVerificationExpiredException.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/exception/EmailVerificationExpiredException.java
@@ -1,9 +1,0 @@
-package com.parksupark.soomjae.server.email.exception;
-
-public class EmailVerificationExpiredException extends RuntimeException {
-
-    public EmailVerificationExpiredException(String message) {
-        super(message);
-    }
-
-}

--- a/src/main/java/com/parksupark/soomjae/server/email/exception/EmailVerificationFailedException.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/exception/EmailVerificationFailedException.java
@@ -1,0 +1,9 @@
+package com.parksupark.soomjae.server.email.exception;
+
+public class EmailVerificationFailedException extends RuntimeException {
+
+    public EmailVerificationFailedException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/parksupark/soomjae/server/email/repository/EmailVerificationRepository.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/repository/EmailVerificationRepository.java
@@ -14,4 +14,22 @@ public interface EmailVerificationRepository extends JpaRepository<EmailVerifica
     @Query("SELECT e FROM EmailVerification e WHERE e.email = :email AND e.expirationTime > :now ")
     Optional<EmailVerification> findByEmailAndExpiredAtAfter(@Param("email") String email,
         @Param("now") Instant now);
+
+    @Query(
+        """
+            SELECT e
+            FROM EmailVerification e
+            WHERE e.email = :email AND e.code = :code AND e.expirationTime > :now
+            """)
+    Optional<EmailVerification> findByEmailAndCodeAndExpirationTimeAfter(@Param("email") String email,
+        @Param("code") String code, @Param("now") Instant now);
+
+    @Query(
+        """
+                SELECT COUNT(e) > 0
+                FROM EmailVerification e
+                WHERE e.email = :email AND e.verified = TRUE AND e.expirationTime > :now
+            """)
+    boolean existsByEmailAndVerifiedAndExpirationTimeAfter(@Param("email") String email,
+        @Param("now") Instant now);
 }

--- a/src/main/java/com/parksupark/soomjae/server/email/repository/EmailVerificationRepository.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/repository/EmailVerificationRepository.java
@@ -11,7 +11,7 @@ public interface EmailVerificationRepository extends JpaRepository<EmailVerifica
 
     void deleteByEmail(String email);
 
-    @Query("SELECT e FROM EmailVerification e WHERE e.email = :email AND e.expiredAt > :now ")
+    @Query("SELECT e FROM EmailVerification e WHERE e.email = :email AND e.expirationTime > :now ")
     Optional<EmailVerification> findByEmailAndExpiredAtAfter(@Param("email") String email,
         @Param("now") Instant now);
 }

--- a/src/main/java/com/parksupark/soomjae/server/email/repository/EmailVerificationRepository.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/repository/EmailVerificationRepository.java
@@ -1,0 +1,10 @@
+package com.parksupark.soomjae.server.email.repository;
+
+import com.parksupark.soomjae.server.email.entity.EmailVerification;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {
+
+    Optional<EmailVerification> findByEmail(String email);
+}

--- a/src/main/java/com/parksupark/soomjae/server/email/repository/EmailVerificationRepository.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/repository/EmailVerificationRepository.java
@@ -1,10 +1,17 @@
 package com.parksupark.soomjae.server.email.repository;
 
 import com.parksupark.soomjae.server.email.entity.EmailVerification;
+import java.time.Instant;
 import java.util.Optional;
+import org.apache.ibatis.annotations.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {
 
-    Optional<EmailVerification> findByEmail(String email);
+    void deleteByEmail(String email);
+
+    @Query("SELECT e FROM EmailVerification e WHERE e.email = :email AND e.expiredAt > :now ")
+    Optional<EmailVerification> findByEmailAndExpiredAtAfter(@Param("email") String email,
+        @Param("now") Instant now);
 }

--- a/src/main/java/com/parksupark/soomjae/server/email/repository/EmailVerificationRepository.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/repository/EmailVerificationRepository.java
@@ -21,7 +21,8 @@ public interface EmailVerificationRepository extends JpaRepository<EmailVerifica
             FROM EmailVerification e
             WHERE e.email = :email AND e.code = :code AND e.expirationTime > :now
             """)
-    Optional<EmailVerification> findByEmailAndCodeAndExpirationTimeAfter(@Param("email") String email,
+    Optional<EmailVerification> findByEmailAndCodeAndExpirationTimeAfter(
+        @Param("email") String email,
         @Param("code") String code, @Param("now") Instant now);
 
     @Query(

--- a/src/main/java/com/parksupark/soomjae/server/email/service/DefaultEmailVerificationService.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/service/DefaultEmailVerificationService.java
@@ -3,7 +3,6 @@ package com.parksupark.soomjae.server.email.service;
 import com.parksupark.soomjae.server.common.exception.ErrorMessages;
 import com.parksupark.soomjae.server.common.exception.ResourceNotFoundException;
 import com.parksupark.soomjae.server.email.entity.EmailVerification;
-import com.parksupark.soomjae.server.email.exception.EmailVerificationExpiredException;
 import com.parksupark.soomjae.server.email.exception.EmailVerificationFailedException;
 import com.parksupark.soomjae.server.email.repository.EmailVerificationRepository;
 import com.parksupark.soomjae.server.email.util.SecureCodeGenerator;
@@ -35,6 +34,8 @@ public class DefaultEmailVerificationService implements EmailVerificationService
 
         String code = codeGenerator.generateVerificationCode();
 
+        emailVerificationRepository.deleteByEmail(email);
+
         emailVerificationRepository.save(EmailVerification.create(email, code));
 
         sendVerificationEmail(email, subject, code);
@@ -43,11 +44,7 @@ public class DefaultEmailVerificationService implements EmailVerificationService
     @Override
     @Transactional
     public void verifyCode(String email, String code) {
-        EmailVerification emailVerification = emailVerificationRepository.findByEmail(email)
-            .orElseThrow(() -> new ResourceNotFoundException(
-                ErrorMessages.EMAIL_VERIFICATION_NOT_FOUND_MESSAGE));
-
-        isExpired(emailVerification);
+        EmailVerification emailVerification = findValidVerification(email);
 
         String normalizedCode = code.toUpperCase().trim();
 
@@ -81,14 +78,9 @@ public class DefaultEmailVerificationService implements EmailVerificationService
         }
     }
 
-    private void isExpired(EmailVerification emailVerification) {
-        Instant expiredAt = emailVerification.getExpiredAt();
-
-        if(expiredAt.isBefore(Instant.now())){
-            emailVerificationRepository.delete(emailVerification);
-
-            throw new EmailVerificationExpiredException(
-                ErrorMessages.EMAIL_VERIFICATION_EXPIRED_MESSAGE);
-        }
+    private EmailVerification findValidVerification(String email) {
+        return emailVerificationRepository.findByEmailAndExpiredAtAfter(email, Instant.now())
+            .orElseThrow(() -> new ResourceNotFoundException(
+                ErrorMessages.EMAIL_VERIFICATION_NOT_FOUND_MESSAGE));
     }
 }

--- a/src/main/java/com/parksupark/soomjae/server/email/service/DefaultEmailVerificationService.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/service/DefaultEmailVerificationService.java
@@ -3,14 +3,17 @@ package com.parksupark.soomjae.server.email.service;
 import com.parksupark.soomjae.server.common.exception.ErrorMessages;
 import com.parksupark.soomjae.server.common.exception.ResourceNotFoundException;
 import com.parksupark.soomjae.server.email.entity.EmailVerification;
-import com.parksupark.soomjae.server.email.exception.EmailVerificationFailedException;
 import com.parksupark.soomjae.server.email.repository.EmailVerificationRepository;
 import com.parksupark.soomjae.server.email.util.EmailSender;
 import com.parksupark.soomjae.server.email.util.SecureCodeGenerator;
 import java.time.Instant;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,32 +32,37 @@ public class DefaultEmailVerificationService implements EmailVerificationService
 
     @Override
     @Transactional
-    public DeferredResult<ResponseEntity<Void>> sendVerificationCode(String email) {
-        log.info("thread name: {}", Thread.currentThread().getName());
-
-        DeferredResult<ResponseEntity<Void>> deferredResult = new DeferredResult<>(DEFERRED_RESULT_TIMEOUT);
-
-        deferredResult.onTimeout(() -> {
-            throw new EmailVerificationFailedException(ErrorMessages.EMAIL_SEND_FAILED_MESSAGE);
-        });
+    public DeferredResult<ResponseEntity<?>> sendVerificationCode(String email) {
+        DeferredResult<ResponseEntity<?>> deferredResult = new DeferredResult<>(DEFERRED_RESULT_TIMEOUT);
 
         String code = codeGenerator.generateVerificationCode();
 
         CompletableFuture<Void> emailFuture = defaultEmailSender.sendVerificationEmail(email,
             code);
 
-        emailFuture.whenComplete((result, throwable) -> {
-            // 비동기 작업에서 예외 발생 시
-            if (throwable != null) {
-                throw new EmailVerificationFailedException(ErrorMessages.EMAIL_SEND_FAILED_MESSAGE);
-            } else {
-                deferredResult.setResult(ResponseEntity.ok().build());
-            }
-        });
+        emailFuture.orTimeout(DEFERRED_RESULT_TIMEOUT, TimeUnit.MILLISECONDS)
+                .whenComplete((result, throwable) -> {
+                    if (throwable != null) {
+                        Throwable cause = throwable.getCause() != null ? throwable.getCause() : throwable;
 
-        emailVerificationRepository.save(EmailVerification.create(email, code));
+                        Map<String, String> body = Map.of("message", cause.getMessage());
 
-        log.info("[{}] 요청 스레드 반납", Thread.currentThread().getName());
+                        ResponseEntity<Map<String, String>> errorResponse = ResponseEntity.status(
+                                HttpStatus.BAD_REQUEST)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .body(body);
+
+                        deferredResult.setResult(errorResponse);
+                    } else {
+                        emailVerificationRepository.save(EmailVerification.create(email, code));
+
+                        Map<String, String> body = Map.of("message", "success");
+                        deferredResult.setResult(ResponseEntity.ok()
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .body(body));
+                    }
+                });
+
         return deferredResult;
     }
 

--- a/src/main/java/com/parksupark/soomjae/server/email/service/DefaultEmailVerificationService.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/service/DefaultEmailVerificationService.java
@@ -5,82 +5,69 @@ import com.parksupark.soomjae.server.common.exception.ResourceNotFoundException;
 import com.parksupark.soomjae.server.email.entity.EmailVerification;
 import com.parksupark.soomjae.server.email.exception.EmailVerificationFailedException;
 import com.parksupark.soomjae.server.email.repository.EmailVerificationRepository;
+import com.parksupark.soomjae.server.email.util.EmailSender;
 import com.parksupark.soomjae.server.email.util.SecureCodeGenerator;
-import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeMessage;
 import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
-import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.javamail.MimeMessageHelper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.thymeleaf.context.Context;
-import org.thymeleaf.spring6.SpringTemplateEngine;
+import org.springframework.web.context.request.async.DeferredResult;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class DefaultEmailVerificationService implements EmailVerificationService {
 
-    private final JavaMailSender javaMailSender;
     private final SecureCodeGenerator codeGenerator;
     private final EmailVerificationRepository emailVerificationRepository;
-    private final SpringTemplateEngine templateEngine;
+    private final EmailSender defaultEmailSender;
 
-    private static final String subject = "[숨재] 회원가입 인증코드";
+    private static final long DEFERRED_RESULT_TIMEOUT = 30 * 1000L;
 
     @Override
     @Transactional
-    public void sendVerificationCode(String email) {
+    public DeferredResult<ResponseEntity<Void>> sendVerificationCode(String email) {
+        log.info("thread name: {}", Thread.currentThread().getName());
+
+        DeferredResult<ResponseEntity<Void>> deferredResult = new DeferredResult<>(DEFERRED_RESULT_TIMEOUT);
+
+        deferredResult.onTimeout(() -> {
+            throw new EmailVerificationFailedException(ErrorMessages.EMAIL_SEND_FAILED_MESSAGE);
+        });
 
         String code = codeGenerator.generateVerificationCode();
 
-        emailVerificationRepository.deleteByEmail(email);
+        CompletableFuture<Void> emailFuture = defaultEmailSender.sendVerificationEmail(email,
+            code);
+
+        emailFuture.whenComplete((result, throwable) -> {
+            // 비동기 작업에서 예외 발생 시
+            if (throwable != null) {
+                throw new EmailVerificationFailedException(ErrorMessages.EMAIL_SEND_FAILED_MESSAGE);
+            } else {
+                deferredResult.setResult(ResponseEntity.ok().build());
+            }
+        });
 
         emailVerificationRepository.save(EmailVerification.create(email, code));
 
-        sendVerificationEmail(email, subject, code);
+        log.info("[{}] 요청 스레드 반납", Thread.currentThread().getName());
+        return deferredResult;
     }
 
     @Override
     @Transactional
     public void verifyCode(String email, String code) {
-        EmailVerification emailVerification = findValidVerification(email);
-
         String normalizedCode = code.toUpperCase().trim();
 
-        if (!normalizedCode.equals(emailVerification.getCode())) {
-            throw new EmailVerificationFailedException(
-                ErrorMessages.EMAIL_VERIFICATION_WRONG_CODE_MESSAGE);
-        }
+        EmailVerification emailVerification = emailVerificationRepository.findByEmailAndCodeAndExpirationTimeAfter(
+            email, normalizedCode,
+            Instant.now()).orElseThrow(() -> new ResourceNotFoundException(
+            ErrorMessages.EMAIL_VERIFICATION_NOT_FOUND_MESSAGE));
 
         emailVerification.setVerified(true);
-    }
-
-    private void sendVerificationEmail(String email, String subject, String code) {
-        try{
-            MimeMessage message = javaMailSender.createMimeMessage();
-            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
-
-            helper.setTo(email);
-            helper.setSubject(subject);
-
-            Context context = new Context();
-            context.setVariable("verificationCode", code);
-            context.setVariable("expirationMinutes", 5);
-
-            String htmlContent = templateEngine.process("email/verification", context);
-            helper.setText(htmlContent, true);
-
-            javaMailSender.send(message);
-
-        } catch (MessagingException e) {
-            throw new EmailVerificationFailedException(ErrorMessages.EMAIL_SEND_FAILED_MESSAGE);
-        }
-    }
-
-    private EmailVerification findValidVerification(String email) {
-        return emailVerificationRepository.findByEmailAndExpiredAtAfter(email, Instant.now())
-            .orElseThrow(() -> new ResourceNotFoundException(
-                ErrorMessages.EMAIL_VERIFICATION_NOT_FOUND_MESSAGE));
     }
 }

--- a/src/main/java/com/parksupark/soomjae/server/email/service/DefaultEmailVerificationService.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/service/DefaultEmailVerificationService.java
@@ -33,7 +33,8 @@ public class DefaultEmailVerificationService implements EmailVerificationService
     @Override
     @Transactional
     public DeferredResult<ResponseEntity<?>> sendVerificationCode(String email) {
-        DeferredResult<ResponseEntity<?>> deferredResult = new DeferredResult<>(DEFERRED_RESULT_TIMEOUT);
+        DeferredResult<ResponseEntity<?>> deferredResult = new DeferredResult<>(
+            DEFERRED_RESULT_TIMEOUT);
 
         String code = codeGenerator.generateVerificationCode();
 
@@ -43,7 +44,8 @@ public class DefaultEmailVerificationService implements EmailVerificationService
         emailFuture.orTimeout(DEFERRED_RESULT_TIMEOUT, TimeUnit.MILLISECONDS)
                 .whenComplete((result, throwable) -> {
                     if (throwable != null) {
-                        Throwable cause = throwable.getCause() != null ? throwable.getCause() : throwable;
+                        Throwable cause =
+                            throwable.getCause() != null ? throwable.getCause() : throwable;
 
                         Map<String, String> body = Map.of("message", cause.getMessage());
 
@@ -71,10 +73,11 @@ public class DefaultEmailVerificationService implements EmailVerificationService
     public void verifyCode(String email, String code) {
         String normalizedCode = code.toUpperCase().trim();
 
-        EmailVerification emailVerification = emailVerificationRepository.findByEmailAndCodeAndExpirationTimeAfter(
-            email, normalizedCode,
-            Instant.now()).orElseThrow(() -> new ResourceNotFoundException(
-            ErrorMessages.EMAIL_VERIFICATION_NOT_FOUND_MESSAGE));
+        EmailVerification emailVerification = emailVerificationRepository
+            .findByEmailAndCodeAndExpirationTimeAfter(
+                email, normalizedCode,
+                Instant.now()).orElseThrow(() -> new ResourceNotFoundException(
+                ErrorMessages.EMAIL_VERIFICATION_NOT_FOUND_MESSAGE));
 
         emailVerification.setVerified(true);
     }

--- a/src/main/java/com/parksupark/soomjae/server/email/service/DefaultEmailVerificationService.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/service/DefaultEmailVerificationService.java
@@ -1,0 +1,94 @@
+package com.parksupark.soomjae.server.email.service;
+
+import com.parksupark.soomjae.server.common.exception.ErrorMessages;
+import com.parksupark.soomjae.server.common.exception.ResourceNotFoundException;
+import com.parksupark.soomjae.server.email.entity.EmailVerification;
+import com.parksupark.soomjae.server.email.exception.EmailVerificationExpiredException;
+import com.parksupark.soomjae.server.email.exception.EmailVerificationFailedException;
+import com.parksupark.soomjae.server.email.repository.EmailVerificationRepository;
+import com.parksupark.soomjae.server.email.util.SecureCodeGenerator;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+@Service
+@RequiredArgsConstructor
+public class DefaultEmailVerificationService implements EmailVerificationService {
+
+    private final JavaMailSender javaMailSender;
+    private final SecureCodeGenerator codeGenerator;
+    private final EmailVerificationRepository emailVerificationRepository;
+    private final SpringTemplateEngine templateEngine;
+
+    private static final String subject = "[숨재] 회원가입 인증코드";
+
+    @Override
+    @Transactional
+    public void sendVerificationCode(String email) {
+
+        String code = codeGenerator.generateVerificationCode();
+
+        emailVerificationRepository.save(EmailVerification.create(email, code));
+
+        sendVerificationEmail(email, subject, code);
+    }
+
+    @Override
+    @Transactional
+    public void verifyCode(String email, String code) {
+        EmailVerification emailVerification = emailVerificationRepository.findByEmail(email)
+            .orElseThrow(() -> new ResourceNotFoundException(
+                ErrorMessages.EMAIL_VERIFICATION_NOT_FOUND_MESSAGE));
+
+        isExpired(emailVerification);
+
+        String normalizedCode = code.toUpperCase().trim();
+
+        if (!normalizedCode.equals(emailVerification.getCode())) {
+            throw new EmailVerificationFailedException(
+                ErrorMessages.EMAIL_VERIFICATION_WRONG_CODE_MESSAGE);
+        }
+
+        emailVerification.setVerified(true);
+    }
+
+    private void sendVerificationEmail(String email, String subject, String code) {
+        try{
+            MimeMessage message = javaMailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+            helper.setTo(email);
+            helper.setSubject(subject);
+
+            Context context = new Context();
+            context.setVariable("verificationCode", code);
+            context.setVariable("expirationMinutes", 5);
+
+            String htmlContent = templateEngine.process("email/verification", context);
+            helper.setText(htmlContent, true);
+
+            javaMailSender.send(message);
+
+        } catch (MessagingException e) {
+            throw new EmailVerificationFailedException(ErrorMessages.EMAIL_SEND_FAILED_MESSAGE);
+        }
+    }
+
+    private void isExpired(EmailVerification emailVerification) {
+        Instant expiredAt = emailVerification.getExpiredAt();
+
+        if(expiredAt.isBefore(Instant.now())){
+            emailVerificationRepository.delete(emailVerification);
+
+            throw new EmailVerificationExpiredException(
+                ErrorMessages.EMAIL_VERIFICATION_EXPIRED_MESSAGE);
+        }
+    }
+}

--- a/src/main/java/com/parksupark/soomjae/server/email/service/EmailVerificationService.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/service/EmailVerificationService.java
@@ -1,8 +1,11 @@
 package com.parksupark.soomjae.server.email.service;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.context.request.async.DeferredResult;
+
 public interface EmailVerificationService {
 
-    void sendVerificationCode(String email);
+    DeferredResult<ResponseEntity<Void>> sendVerificationCode(String email);
 
     void verifyCode(String email, String code);
 

--- a/src/main/java/com/parksupark/soomjae/server/email/service/EmailVerificationService.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/service/EmailVerificationService.java
@@ -1,0 +1,9 @@
+package com.parksupark.soomjae.server.email.service;
+
+public interface EmailVerificationService {
+
+    void sendVerificationCode(String email);
+
+    void verifyCode(String email, String code);
+
+}

--- a/src/main/java/com/parksupark/soomjae/server/email/service/EmailVerificationService.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/service/EmailVerificationService.java
@@ -5,7 +5,7 @@ import org.springframework.web.context.request.async.DeferredResult;
 
 public interface EmailVerificationService {
 
-    DeferredResult<ResponseEntity<Void>> sendVerificationCode(String email);
+    DeferredResult<ResponseEntity<?>> sendVerificationCode(String email);
 
     void verifyCode(String email, String code);
 

--- a/src/main/java/com/parksupark/soomjae/server/email/util/DefaultEmailSender.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/util/DefaultEmailSender.java
@@ -1,0 +1,56 @@
+package com.parksupark.soomjae.server.email.util;
+
+import com.parksupark.soomjae.server.common.exception.ErrorMessages;
+import com.parksupark.soomjae.server.email.exception.EmailVerificationFailedException;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import java.util.concurrent.CompletableFuture;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DefaultEmailSender implements EmailSender {
+
+    private final JavaMailSender javaMailSender;
+    private final SpringTemplateEngine templateEngine;
+
+    private static final String SUBJECT = "[숨재] 회원가입 인증코드";
+    private static final String TEMPLATE_PATH = "email/verification";
+
+    @Async
+    @Override
+    public CompletableFuture<Void> sendVerificationEmail(String email, String code) {
+        try {
+            log.info("thread name: {}", Thread.currentThread().getName());
+            MimeMessage message = javaMailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+            helper.setTo(email);
+            helper.setSubject(SUBJECT);
+
+            Context context = new Context();
+            context.setVariable("verificationCode", code);
+            context.setVariable("expirationMinutes", 60);
+
+            String htmlContent = templateEngine.process(TEMPLATE_PATH, context);
+            helper.setText(htmlContent, true);
+
+            javaMailSender.send(message);
+
+            log.info("[{}] 비동기 스레드 반납", Thread.currentThread().getName());
+            return CompletableFuture.completedFuture(null);
+
+        } catch (MessagingException e) {
+            throw new EmailVerificationFailedException(ErrorMessages.EMAIL_SEND_FAILED_MESSAGE);
+        }
+    }
+
+}

--- a/src/main/java/com/parksupark/soomjae/server/email/util/DefaultEmailSender.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/util/DefaultEmailSender.java
@@ -45,7 +45,6 @@ public class DefaultEmailSender implements EmailSender {
 
             javaMailSender.send(message);
 
-            log.info("[{}] 비동기 스레드 반납", Thread.currentThread().getName());
             return CompletableFuture.completedFuture(null);
 
         } catch (MessagingException e) {

--- a/src/main/java/com/parksupark/soomjae/server/email/util/EmailSender.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/util/EmailSender.java
@@ -1,0 +1,8 @@
+package com.parksupark.soomjae.server.email.util;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface EmailSender {
+
+    CompletableFuture<Void> sendVerificationEmail(String email, String code);
+}

--- a/src/main/java/com/parksupark/soomjae/server/email/util/SecureCodeGenerator.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/util/SecureCodeGenerator.java
@@ -1,0 +1,19 @@
+package com.parksupark.soomjae.server.email.util;
+
+import java.security.SecureRandom;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SecureCodeGenerator {
+
+    private final SecureRandom secureRandom = new SecureRandom();
+    private static final String SAFE_CHARS = "23456789ABCDEFGHJKMNPQRSTUVWXYZ";
+
+    public String generateVerificationCode() {
+        StringBuilder code = new StringBuilder();
+        for (int i = 0; i < 6; i++) {
+            code.append(SAFE_CHARS.charAt(secureRandom.nextInt(SAFE_CHARS.length())));
+        }
+        return code.toString();
+    }
+}

--- a/src/main/java/com/parksupark/soomjae/server/email/util/SecureCodeGenerator.java
+++ b/src/main/java/com/parksupark/soomjae/server/email/util/SecureCodeGenerator.java
@@ -8,10 +8,11 @@ public class SecureCodeGenerator {
 
     private final SecureRandom secureRandom = new SecureRandom();
     private static final String SAFE_CHARS = "23456789ABCDEFGHJKMNPQRSTUVWXYZ";
+    private static final int CODE_LENGTH = 6;
 
     public String generateVerificationCode() {
-        StringBuilder code = new StringBuilder();
-        for (int i = 0; i < 6; i++) {
+        StringBuilder code = new StringBuilder(CODE_LENGTH);
+        for (int i = 0; i < CODE_LENGTH; i++) {
             code.append(SAFE_CHARS.charAt(secureRandom.nextInt(SAFE_CHARS.length())));
         }
         return code.toString();

--- a/src/main/java/com/parksupark/soomjae/server/member/service/DefaultMemberService.java
+++ b/src/main/java/com/parksupark/soomjae/server/member/service/DefaultMemberService.java
@@ -13,6 +13,7 @@ import com.parksupark.soomjae.server.member.entity.Member;
 import com.parksupark.soomjae.server.member.exception.DuplicateEmailException;
 import com.parksupark.soomjae.server.member.exception.MemberNotFoundException;
 import com.parksupark.soomjae.server.member.repository.MemberRepository;
+import java.time.Instant;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -36,15 +37,13 @@ public class DefaultMemberService implements MemberService {
 
         validateEmailAndProviderUniqueness(email, AuthProvider.LOCAL);
 
-        EmailVerification emailVerification = emailVerificationRepository.findByEmail(email)
-            .orElseThrow(() -> new ResourceNotFoundException(
-                ErrorMessages.EMAIL_VERIFICATION_NOT_FOUND_MESSAGE));
+        EmailVerification emailVerification = findValidVerification(email);
 
         if (!emailVerification.isVerified()) {
             throw new IllegalArgumentException(ErrorMessages.EMAIL_NOT_VERIFIED_MESSAGE);
         }
 
-        emailVerificationRepository.delete(emailVerification);
+        emailVerificationRepository.deleteByEmail(email);
 
         final String encodedPassword = passwordEncoder.encode(request.getPassword());
         final String nickname = request.getNickname();
@@ -131,6 +130,12 @@ public class DefaultMemberService implements MemberService {
         if (memberRepository.existsByEmailAndProvider(email, provider)) {
             throw new DuplicateEmailException(ErrorMessages.DUPLICATE_EMAIL_EXCEPTION_MESSAGE);
         }
+    }
+
+    private EmailVerification findValidVerification(String email) {
+        return emailVerificationRepository.findByEmailAndExpiredAtAfter(email, Instant.now())
+            .orElseThrow(() -> new ResourceNotFoundException(
+                ErrorMessages.EMAIL_VERIFICATION_NOT_FOUND_MESSAGE));
     }
 
 }

--- a/src/main/java/com/parksupark/soomjae/server/member/service/DefaultMemberService.java
+++ b/src/main/java/com/parksupark/soomjae/server/member/service/DefaultMemberService.java
@@ -2,6 +2,9 @@ package com.parksupark.soomjae.server.member.service;
 
 import com.parksupark.soomjae.server.auth.oauth.AuthProvider;
 import com.parksupark.soomjae.server.common.exception.ErrorMessages;
+import com.parksupark.soomjae.server.common.exception.ResourceNotFoundException;
+import com.parksupark.soomjae.server.email.entity.EmailVerification;
+import com.parksupark.soomjae.server.email.repository.EmailVerificationRepository;
 import com.parksupark.soomjae.server.member.dto.CheckDuplicateEmailResponse;
 import com.parksupark.soomjae.server.member.dto.CreateMemberRequest;
 import com.parksupark.soomjae.server.member.dto.MemberBasicInfo;
@@ -23,6 +26,7 @@ public class DefaultMemberService implements MemberService {
 
     private final PasswordEncoder passwordEncoder;
     private final MemberRepository memberRepository;
+    private final EmailVerificationRepository emailVerificationRepository;
 
     // nickname 필드에 대한 중복 체크는 추후에 자세한 nickname 초기화 정책이 나오면 구현
     @Transactional
@@ -31,6 +35,16 @@ public class DefaultMemberService implements MemberService {
         final String email = request.getEmail();
 
         validateEmailAndProviderUniqueness(email, AuthProvider.LOCAL);
+
+        EmailVerification emailVerification = emailVerificationRepository.findByEmail(email)
+            .orElseThrow(() -> new ResourceNotFoundException(
+                ErrorMessages.EMAIL_VERIFICATION_NOT_FOUND_MESSAGE));
+
+        if (!emailVerification.isVerified()) {
+            throw new IllegalArgumentException(ErrorMessages.EMAIL_NOT_VERIFIED_MESSAGE);
+        }
+
+        emailVerificationRepository.delete(emailVerification);
 
         final String encodedPassword = passwordEncoder.encode(request.getPassword());
         final String nickname = request.getNickname();

--- a/src/main/java/com/parksupark/soomjae/server/member/service/DefaultMemberService.java
+++ b/src/main/java/com/parksupark/soomjae/server/member/service/DefaultMemberService.java
@@ -2,8 +2,6 @@ package com.parksupark.soomjae.server.member.service;
 
 import com.parksupark.soomjae.server.auth.oauth.AuthProvider;
 import com.parksupark.soomjae.server.common.exception.ErrorMessages;
-import com.parksupark.soomjae.server.common.exception.ResourceNotFoundException;
-import com.parksupark.soomjae.server.email.entity.EmailVerification;
 import com.parksupark.soomjae.server.email.repository.EmailVerificationRepository;
 import com.parksupark.soomjae.server.member.dto.CheckDuplicateEmailResponse;
 import com.parksupark.soomjae.server.member.dto.CreateMemberRequest;
@@ -37,19 +35,17 @@ public class DefaultMemberService implements MemberService {
 
         validateEmailAndProviderUniqueness(email, AuthProvider.LOCAL);
 
-        EmailVerification emailVerification = findValidVerification(email);
-
-        if (!emailVerification.isVerified()) {
+        if (!emailVerificationRepository.existsByEmailAndVerifiedAndExpirationTimeAfter(email,
+            Instant.now())) {
             throw new IllegalArgumentException(ErrorMessages.EMAIL_NOT_VERIFIED_MESSAGE);
         }
-
-        emailVerificationRepository.deleteByEmail(email);
 
         final String encodedPassword = passwordEncoder.encode(request.getPassword());
         final String nickname = request.getNickname();
 
         Member member = Member.create(email, encodedPassword, nickname);
         memberRepository.save(member);
+        emailVerificationRepository.deleteByEmail(email);
         return createMemberResponse(member);
     }
 
@@ -130,12 +126,6 @@ public class DefaultMemberService implements MemberService {
         if (memberRepository.existsByEmailAndProvider(email, provider)) {
             throw new DuplicateEmailException(ErrorMessages.DUPLICATE_EMAIL_EXCEPTION_MESSAGE);
         }
-    }
-
-    private EmailVerification findValidVerification(String email) {
-        return emailVerificationRepository.findByEmailAndExpiredAtAfter(email, Instant.now())
-            .orElseThrow(() -> new ResourceNotFoundException(
-                ErrorMessages.EMAIL_VERIFICATION_NOT_FOUND_MESSAGE));
     }
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -62,3 +62,18 @@ jwt.refresh.secret=${jwt.refresh.secret}
 # 쿠키 보안 설정
 # ===============================
 app.cookie.secure=false
+# ===============================
+# 이메일 전송
+# ===============================
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=${mail.username}
+spring.mail.password=${mail.password}
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
+spring.mail.properties.mail.smtp.starttls.required=true
+spring.mail.properties.mail.smtp.connectiontimeout=5000
+spring.mail.properties.mail.smtp.timeout=5000
+spring.mail.properties.mail.smtp.writetimeout=5000
+spring.mail.properties.mail.smtp.connectionpoolsize=10
+spring.mail.properties.mail.smtp.connectionpooltimeout=300000

--- a/src/main/resources/templates/email/verification.html
+++ b/src/main/resources/templates/email/verification.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>숨재 이메일 인증</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background-color: #f6f9fc;
+      padding: 20px;
+      line-height: 1.6;
+    }
+
+    .email-container {
+      max-width: 600px;
+      margin: 0 auto;
+      background: white;
+      border-radius: 12px;
+      box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
+      overflow: hidden;
+    }
+
+    .header {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      padding: 40px 30px;
+      text-align: center;
+    }
+
+    .header h1 {
+      font-size: 28px;
+      margin-bottom: 10px;
+    }
+
+    .content {
+      padding: 40px 30px;
+    }
+
+    .welcome-text {
+      font-size: 18px;
+      color: #2c3e50;
+      margin-bottom: 30px;
+      text-align: center;
+    }
+
+    .code-section {
+      text-align: center;
+      margin: 30px 0;
+    }
+
+    .code-label {
+      font-size: 16px;
+      color: #7f8c8d;
+      margin-bottom: 15px;
+    }
+
+    .verification-code {
+      display: inline-block;
+      background: linear-gradient(135deg, #3498db, #2980b9);
+      color: white;
+      font-size: 32px;
+      font-weight: bold;
+      letter-spacing: 8px;
+      padding: 20px 40px;
+      border-radius: 10px;
+      box-shadow: 0 4px 15px rgba(52, 152, 219, 0.3);
+      font-family: 'Courier New', monospace;
+      user-select: all;
+      cursor: pointer;
+    }
+
+    .verification-code:hover {
+      transform: translateY(-2px);
+      transition: transform 0.2s ease;
+    }
+
+    .instructions {
+      background-color: #ecf0f1;
+      border-radius: 8px;
+      padding: 25px;
+      margin: 30px 0;
+    }
+
+    .instructions h3 {
+      color: #2c3e50;
+      margin-bottom: 15px;
+      font-size: 18px;
+    }
+
+    .instructions ol {
+      color: #34495e;
+      padding-left: 20px;
+    }
+
+    .instructions li {
+      margin-bottom: 8px;
+    }
+
+    .warning {
+      background-color: #fff3cd;
+      border-left: 4px solid #ffc107;
+      border-radius: 8px;
+      padding: 20px;
+      margin: 25px 0;
+    }
+
+    .warning h4 {
+      color: #856404;
+      margin-bottom: 10px;
+      display: flex;
+      align-items: center;
+    }
+
+    .warning ul {
+      color: #856404;
+      padding-left: 20px;
+    }
+
+    .warning li {
+      margin-bottom: 5px;
+    }
+
+    .footer {
+      background-color: #2c3e50;
+      color: #bdc3c7;
+      padding: 30px;
+      text-align: center;
+    }
+
+    .footer h4 {
+      color: white;
+      margin-bottom: 15px;
+    }
+
+    .footer p {
+      margin-bottom: 8px;
+      font-size: 14px;
+    }
+
+    .divider {
+      border: none;
+      border-top: 1px solid #ecf0f1;
+      margin: 25px 0;
+    }
+
+    .highlight {
+      background-color: #e8f5e8;
+      padding: 2px 4px;
+      border-radius: 3px;
+      font-weight: bold;
+    }
+
+    @media (max-width: 600px) {
+      body { padding: 10px; }
+      .email-container { margin: 0; }
+      .header, .content, .footer { padding: 25px 20px; }
+      .verification-code {
+        font-size: 24px;
+        letter-spacing: 4px;
+        padding: 15px 25px;
+      }
+    }
+  </style>
+</head>
+<body>
+<div class="email-container">
+  <div class="header">
+    <h1>숨재</h1>
+  </div>
+
+  <div class="content">
+    <p class="welcome-text">
+      안녕하세요!<br>
+      숨재 커뮤니티 가입을 위한 이메일 인증을 진행해주세요.
+    </p>
+
+    <div class="code-section">
+      <p class="code-label">아래 인증코드를 입력해주세요</p>
+      <div class="verification-code" th:text="${verificationCode}">123456</div>
+    </div>
+
+    <div class="instructions">
+      <h3>인증 방법</h3>
+      <ol>
+        <li>위의 <span class="highlight">6자리 인증코드</span>를 복사하세요</li>
+        <li>회원가입 페이지로 돌아가세요</li>
+        <li>인증코드 입력란에 붙여넣기 하세요</li>
+        <li><strong>'인증하기'</strong> 버튼을 클릭하세요</li>
+      </ol>
+    </div>
+
+    <hr class="divider">
+
+    <div class="warning">
+      <h4>⚠️ 보안 안내사항</h4>
+      <ul>
+        <li><strong>유효시간:</strong> 이 코드는 <span th:text="${expirationMinutes}">5</span>분간만 유효합니다</li>
+        <li><strong>보안:</strong> 코드를 타인과 공유하지 마세요</li>
+        <li><strong>의심스러운 요청:</strong> 본인이 요청하지 않았다면 이 이메일을 무시하세요</li>
+      </ul>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/src/test/java/com/parksupark/soomjae/server/email/repository/NoOpEmailVerificationRepository.java
+++ b/src/test/java/com/parksupark/soomjae/server/email/repository/NoOpEmailVerificationRepository.java
@@ -13,6 +13,10 @@ import org.springframework.data.repository.query.FluentQuery.FetchableFluentQuer
 
 public class NoOpEmailVerificationRepository implements EmailVerificationRepository {
 
+    public NoOpEmailVerificationRepository() {
+        super();
+    }
+
     @Override
     public void deleteByEmail(String email) {
     }
@@ -33,34 +37,127 @@ public class NoOpEmailVerificationRepository implements EmailVerificationReposit
         return false;
     }
 
-    public NoOpEmailVerificationRepository() {
-        super();
+    // ------------------------------------------------------------------------
+    // Basic CRUD Methods
+    // ------------------------------------------------------------------------
+
+    @Override
+    public <S extends EmailVerification> S save(S entity) {
+        return null;
     }
 
     @Override
-    public int hashCode() {
-        return super.hashCode();
+    public <S extends EmailVerification> List<S> saveAll(Iterable<S> entities) {
+        return List.of();
     }
 
     @Override
-    public boolean equals(Object obj) {
-        return super.equals(obj);
+    public Optional<EmailVerification> findById(Long id) {
+        return Optional.empty();
     }
 
     @Override
-    protected Object clone() throws CloneNotSupportedException {
-        return super.clone();
+    public boolean existsById(Long id) {
+        return false;
     }
 
     @Override
-    public String toString() {
-        return super.toString();
+    public List<EmailVerification> findAll() {
+        return List.of();
+    }
+
+    @Override
+    public List<EmailVerification> findAllById(Iterable<Long> ids) {
+        return List.of();
+    }
+
+    @Override
+    public long count() {
+        return 0;
+    }
+
+    @Override
+    public void deleteById(Long id) {
+    }
+
+    @Override
+    public void delete(EmailVerification entity) {
+    }
+
+    @Override
+    public void deleteAllById(Iterable<? extends Long> ids) {
+    }
+
+    @Override
+    public void deleteAll(Iterable<? extends EmailVerification> entities) {
+    }
+
+    @Override
+    public void deleteAll() {
+    }
+
+    // ------------------------------------------------------------------------
+    // Advanced JPA Methods
+    // ------------------------------------------------------------------------
+
+    @Override
+    public void flush() {
+    }
+
+    @Override
+    public <S extends EmailVerification> S saveAndFlush(S entity) {
+        return null;
+    }
+
+    @Override
+    public <S extends EmailVerification> List<S> saveAllAndFlush(Iterable<S> entities) {
+        return List.of();
+    }
+
+    @Override
+    public void deleteAllInBatch() {
+    }
+
+    @Override
+    public void deleteAllInBatch(Iterable<EmailVerification> entities) {
+    }
+
+    @Override
+    public void deleteAllByIdInBatch(Iterable<Long> ids) {
+    }
+
+    @Override
+    public EmailVerification getOne(Long id) {
+        return null;
+    }
+
+    @Override
+    public EmailVerification getById(Long id) {
+        return null;
     }
 
     @Override
     public EmailVerification getReferenceById(Long id) {
         return null;
     }
+
+    // ------------------------------------------------------------------------
+    // Sorting & Paging
+    // ------------------------------------------------------------------------
+
+    @Override
+    public List<EmailVerification> findAll(Sort sort) {
+        return List.of();
+    }
+
+    @Override
+    public Page<EmailVerification> findAll(Pageable pageable) {
+        return null;
+    }
+
+    // ------------------------------------------------------------------------
+    // Example Queries
+    // ------------------------------------------------------------------------
 
     @Override
     public <S extends EmailVerification> Optional<S> findOne(Example<S> example) {
@@ -98,104 +195,27 @@ public class NoOpEmailVerificationRepository implements EmailVerificationReposit
         return null;
     }
 
+    // ------------------------------------------------------------------------
+    // Object methods
+    // ------------------------------------------------------------------------
+
     @Override
-    public void flush() {
+    public int hashCode() {
+        return super.hashCode();
     }
 
     @Override
-    public <S extends EmailVerification> S saveAndFlush(S entity) {
-        return null;
+    public boolean equals(Object obj) {
+        return super.equals(obj);
     }
 
     @Override
-    public <S extends EmailVerification> List<S> saveAllAndFlush(Iterable<S> entities) {
-        return List.of();
+    protected Object clone() throws CloneNotSupportedException {
+        return super.clone();
     }
 
     @Override
-    public void deleteAllInBatch(Iterable<EmailVerification> entities) {
-    }
-
-    @Override
-    public void deleteAllByIdInBatch(Iterable<Long> ids) {
-    }
-
-    @Override
-    public void deleteAllInBatch() {
-    }
-
-    @Override
-    public EmailVerification getOne(Long id) {
-        return null;
-    }
-
-    @Override
-    public EmailVerification getById(Long id) {
-        return null;
-    }
-
-    @Override
-    public Optional<EmailVerification> findById(Long id) {
-        return Optional.empty();
-    }
-
-    @Override
-    public boolean existsById(Long id) {
-        return false;
-    }
-
-    @Override
-    public void deleteById(Long id) {
-    }
-
-    @Override
-    public List<EmailVerification> findAll() {
-        return List.of();
-    }
-
-    @Override
-    public List<EmailVerification> findAllById(Iterable<Long> ids) {
-        return List.of();
-    }
-
-    @Override
-    public List<EmailVerification> findAll(Sort sort) {
-        return List.of();
-    }
-
-    @Override
-    public Page<EmailVerification> findAll(Pageable pageable) {
-        return null;
-    }
-
-    @Override
-    public <S extends EmailVerification> S save(S entity) {
-        return null;
-    }
-
-    @Override
-    public <S extends EmailVerification> List<S> saveAll(Iterable<S> entities) {
-        return List.of();
-    }
-
-    @Override
-    public void delete(EmailVerification entity) {
-    }
-
-    @Override
-    public void deleteAllById(Iterable<? extends Long> ids) {
-    }
-
-    @Override
-    public void deleteAll(Iterable<? extends EmailVerification> entities) {
-    }
-
-    @Override
-    public void deleteAll() {
-    }
-
-    @Override
-    public long count() {
-        return 0;
+    public String toString() {
+        return super.toString();
     }
 }

--- a/src/test/java/com/parksupark/soomjae/server/email/repository/NoOpEmailVerificationRepository.java
+++ b/src/test/java/com/parksupark/soomjae/server/email/repository/NoOpEmailVerificationRepository.java
@@ -15,7 +15,6 @@ public class NoOpEmailVerificationRepository implements EmailVerificationReposit
 
     @Override
     public void deleteByEmail(String email) {
-
     }
 
     @Override
@@ -24,8 +23,8 @@ public class NoOpEmailVerificationRepository implements EmailVerificationReposit
     }
 
     @Override
-    public Optional<EmailVerification> findByEmailAndCodeAndExpirationTimeAfter(String email,
-        String code, Instant now) {
+    public Optional<EmailVerification> findByEmailAndCodeAndExpirationTimeAfter(
+        String email, String code, Instant now) {
         return Optional.empty();
     }
 
@@ -59,7 +58,7 @@ public class NoOpEmailVerificationRepository implements EmailVerificationReposit
     }
 
     @Override
-    public EmailVerification getReferenceById(Long aLong) {
+    public EmailVerification getReferenceById(Long id) {
         return null;
     }
 
@@ -94,14 +93,13 @@ public class NoOpEmailVerificationRepository implements EmailVerificationReposit
     }
 
     @Override
-    public <S extends EmailVerification, R> R findBy(Example<S> example,
-        Function<FetchableFluentQuery<S>, R> queryFunction) {
+    public <S extends EmailVerification, R> R findBy(
+        Example<S> example, Function<FetchableFluentQuery<S>, R> queryFunction) {
         return null;
     }
 
     @Override
     public void flush() {
-
     }
 
     @Override
@@ -116,26 +114,57 @@ public class NoOpEmailVerificationRepository implements EmailVerificationReposit
 
     @Override
     public void deleteAllInBatch(Iterable<EmailVerification> entities) {
-
     }
 
     @Override
-    public void deleteAllByIdInBatch(Iterable<Long> longs) {
-
+    public void deleteAllByIdInBatch(Iterable<Long> ids) {
     }
 
     @Override
     public void deleteAllInBatch() {
-
     }
 
     @Override
-    public EmailVerification getOne(Long aLong) {
+    public EmailVerification getOne(Long id) {
         return null;
     }
 
     @Override
-    public EmailVerification getById(Long aLong) {
+    public EmailVerification getById(Long id) {
+        return null;
+    }
+
+    @Override
+    public Optional<EmailVerification> findById(Long id) {
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean existsById(Long id) {
+        return false;
+    }
+
+    @Override
+    public void deleteById(Long id) {
+    }
+
+    @Override
+    public List<EmailVerification> findAll() {
+        return List.of();
+    }
+
+    @Override
+    public List<EmailVerification> findAllById(Iterable<Long> ids) {
+        return List.of();
+    }
+
+    @Override
+    public List<EmailVerification> findAll(Sort sort) {
+        return List.of();
+    }
+
+    @Override
+    public Page<EmailVerification> findAll(Pageable pageable) {
         return null;
     }
 
@@ -150,62 +179,23 @@ public class NoOpEmailVerificationRepository implements EmailVerificationReposit
     }
 
     @Override
-    public Optional<EmailVerification> findById(Long aLong) {
-        return Optional.empty();
+    public void delete(EmailVerification entity) {
     }
 
     @Override
-    public boolean existsById(Long aLong) {
-        return false;
+    public void deleteAllById(Iterable<? extends Long> ids) {
     }
 
     @Override
-    public List<EmailVerification> findAll() {
-        return List.of();
+    public void deleteAll(Iterable<? extends EmailVerification> entities) {
     }
 
     @Override
-    public List<EmailVerification> findAllById(Iterable<Long> longs) {
-        return List.of();
+    public void deleteAll() {
     }
 
     @Override
     public long count() {
         return 0;
-    }
-
-    @Override
-    public void deleteById(Long aLong) {
-
-    }
-
-    @Override
-    public void delete(EmailVerification entity) {
-
-    }
-
-    @Override
-    public void deleteAllById(Iterable<? extends Long> longs) {
-
-    }
-
-    @Override
-    public void deleteAll(Iterable<? extends EmailVerification> entities) {
-
-    }
-
-    @Override
-    public void deleteAll() {
-
-    }
-
-    @Override
-    public List<EmailVerification> findAll(Sort sort) {
-        return List.of();
-    }
-
-    @Override
-    public Page<EmailVerification> findAll(Pageable pageable) {
-        return null;
     }
 }

--- a/src/test/java/com/parksupark/soomjae/server/email/repository/NoOpEmailVerificationRepository.java
+++ b/src/test/java/com/parksupark/soomjae/server/email/repository/NoOpEmailVerificationRepository.java
@@ -1,0 +1,211 @@
+package com.parksupark.soomjae.server.email.repository;
+
+import com.parksupark.soomjae.server.email.entity.EmailVerification;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import org.springframework.data.domain.Example;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.repository.query.FluentQuery.FetchableFluentQuery;
+
+public class NoOpEmailVerificationRepository implements EmailVerificationRepository {
+
+    @Override
+    public void deleteByEmail(String email) {
+
+    }
+
+    @Override
+    public Optional<EmailVerification> findByEmailAndExpiredAtAfter(String email, Instant now) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<EmailVerification> findByEmailAndCodeAndExpirationTimeAfter(String email,
+        String code, Instant now) {
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean existsByEmailAndVerifiedAndExpirationTimeAfter(String email, Instant now) {
+        return false;
+    }
+
+    public NoOpEmailVerificationRepository() {
+        super();
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return super.equals(obj);
+    }
+
+    @Override
+    protected Object clone() throws CloneNotSupportedException {
+        return super.clone();
+    }
+
+    @Override
+    public String toString() {
+        return super.toString();
+    }
+
+    @Override
+    public EmailVerification getReferenceById(Long aLong) {
+        return null;
+    }
+
+    @Override
+    public <S extends EmailVerification> Optional<S> findOne(Example<S> example) {
+        return Optional.empty();
+    }
+
+    @Override
+    public <S extends EmailVerification> List<S> findAll(Example<S> example) {
+        return List.of();
+    }
+
+    @Override
+    public <S extends EmailVerification> List<S> findAll(Example<S> example, Sort sort) {
+        return List.of();
+    }
+
+    @Override
+    public <S extends EmailVerification> Page<S> findAll(Example<S> example, Pageable pageable) {
+        return null;
+    }
+
+    @Override
+    public <S extends EmailVerification> long count(Example<S> example) {
+        return 0;
+    }
+
+    @Override
+    public <S extends EmailVerification> boolean exists(Example<S> example) {
+        return false;
+    }
+
+    @Override
+    public <S extends EmailVerification, R> R findBy(Example<S> example,
+        Function<FetchableFluentQuery<S>, R> queryFunction) {
+        return null;
+    }
+
+    @Override
+    public void flush() {
+
+    }
+
+    @Override
+    public <S extends EmailVerification> S saveAndFlush(S entity) {
+        return null;
+    }
+
+    @Override
+    public <S extends EmailVerification> List<S> saveAllAndFlush(Iterable<S> entities) {
+        return List.of();
+    }
+
+    @Override
+    public void deleteAllInBatch(Iterable<EmailVerification> entities) {
+
+    }
+
+    @Override
+    public void deleteAllByIdInBatch(Iterable<Long> longs) {
+
+    }
+
+    @Override
+    public void deleteAllInBatch() {
+
+    }
+
+    @Override
+    public EmailVerification getOne(Long aLong) {
+        return null;
+    }
+
+    @Override
+    public EmailVerification getById(Long aLong) {
+        return null;
+    }
+
+    @Override
+    public <S extends EmailVerification> S save(S entity) {
+        return null;
+    }
+
+    @Override
+    public <S extends EmailVerification> List<S> saveAll(Iterable<S> entities) {
+        return List.of();
+    }
+
+    @Override
+    public Optional<EmailVerification> findById(Long aLong) {
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean existsById(Long aLong) {
+        return false;
+    }
+
+    @Override
+    public List<EmailVerification> findAll() {
+        return List.of();
+    }
+
+    @Override
+    public List<EmailVerification> findAllById(Iterable<Long> longs) {
+        return List.of();
+    }
+
+    @Override
+    public long count() {
+        return 0;
+    }
+
+    @Override
+    public void deleteById(Long aLong) {
+
+    }
+
+    @Override
+    public void delete(EmailVerification entity) {
+
+    }
+
+    @Override
+    public void deleteAllById(Iterable<? extends Long> longs) {
+
+    }
+
+    @Override
+    public void deleteAll(Iterable<? extends EmailVerification> entities) {
+
+    }
+
+    @Override
+    public void deleteAll() {
+
+    }
+
+    @Override
+    public List<EmailVerification> findAll(Sort sort) {
+        return List.of();
+    }
+
+    @Override
+    public Page<EmailVerification> findAll(Pageable pageable) {
+        return null;
+    }
+}

--- a/src/test/java/com/parksupark/soomjae/server/email/repository/NoOpEmailVerificationRepository.java
+++ b/src/test/java/com/parksupark/soomjae/server/email/repository/NoOpEmailVerificationRepository.java
@@ -37,10 +37,6 @@ public class NoOpEmailVerificationRepository implements EmailVerificationReposit
         return false;
     }
 
-    // ------------------------------------------------------------------------
-    // Basic CRUD Methods
-    // ------------------------------------------------------------------------
-
     @Override
     public <S extends EmailVerification> S save(S entity) {
         return null;
@@ -62,17 +58,17 @@ public class NoOpEmailVerificationRepository implements EmailVerificationReposit
     }
 
     @Override
-    public List<EmailVerification> findAll() {
-        return List.of();
-    }
-
-    @Override
     public List<EmailVerification> findAllById(Iterable<Long> ids) {
         return List.of();
     }
 
     @Override
     public long count() {
+        return 0;
+    }
+
+    @Override
+    public <S extends EmailVerification> long count(Example<S> example) {
         return 0;
     }
 
@@ -95,10 +91,6 @@ public class NoOpEmailVerificationRepository implements EmailVerificationReposit
     @Override
     public void deleteAll() {
     }
-
-    // ------------------------------------------------------------------------
-    // Advanced JPA Methods
-    // ------------------------------------------------------------------------
 
     @Override
     public void flush() {
@@ -141,9 +133,15 @@ public class NoOpEmailVerificationRepository implements EmailVerificationReposit
         return null;
     }
 
-    // ------------------------------------------------------------------------
-    // Sorting & Paging
-    // ------------------------------------------------------------------------
+    @Override
+    public <S extends EmailVerification> Optional<S> findOne(Example<S> example) {
+        return Optional.empty();
+    }
+
+    @Override
+    public List<EmailVerification> findAll() {
+        return List.of();
+    }
 
     @Override
     public List<EmailVerification> findAll(Sort sort) {
@@ -153,15 +151,6 @@ public class NoOpEmailVerificationRepository implements EmailVerificationReposit
     @Override
     public Page<EmailVerification> findAll(Pageable pageable) {
         return null;
-    }
-
-    // ------------------------------------------------------------------------
-    // Example Queries
-    // ------------------------------------------------------------------------
-
-    @Override
-    public <S extends EmailVerification> Optional<S> findOne(Example<S> example) {
-        return Optional.empty();
     }
 
     @Override
@@ -180,11 +169,6 @@ public class NoOpEmailVerificationRepository implements EmailVerificationReposit
     }
 
     @Override
-    public <S extends EmailVerification> long count(Example<S> example) {
-        return 0;
-    }
-
-    @Override
     public <S extends EmailVerification> boolean exists(Example<S> example) {
         return false;
     }
@@ -194,10 +178,6 @@ public class NoOpEmailVerificationRepository implements EmailVerificationReposit
         Example<S> example, Function<FetchableFluentQuery<S>, R> queryFunction) {
         return null;
     }
-
-    // ------------------------------------------------------------------------
-    // Object methods
-    // ------------------------------------------------------------------------
 
     @Override
     public int hashCode() {

--- a/src/test/java/com/parksupark/soomjae/server/member/service/DefaultMemberServiceUnitTest.java
+++ b/src/test/java/com/parksupark/soomjae/server/member/service/DefaultMemberServiceUnitTest.java
@@ -3,6 +3,8 @@ package com.parksupark.soomjae.server.member.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.parksupark.soomjae.server.email.repository.EmailVerificationRepository;
+import com.parksupark.soomjae.server.email.repository.NoOpEmailVerificationRepository;
 import com.parksupark.soomjae.server.member.dto.CheckDuplicateEmailResponse;
 import com.parksupark.soomjae.server.member.dto.CreateMemberRequest;
 import com.parksupark.soomjae.server.member.dto.MemberResponse;
@@ -22,12 +24,13 @@ class DefaultMemberServiceUnitTest {
 
     private final MemberRepository memberRepository = new JpaLikeInMemoryMemberRepository();
     private final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+    private final EmailVerificationRepository emailVerificationRepository = new NoOpEmailVerificationRepository();
     private final String email = "test@example.com";
     private final String password = "test";
     private final String nickname = "test";
 
     private final MemberService memberService = new DefaultMemberService(passwordEncoder,
-        memberRepository);
+        memberRepository, emailVerificationRepository);
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/com/parksupark/soomjae/server/member/service/DefaultMemberServiceUnitTest.java
+++ b/src/test/java/com/parksupark/soomjae/server/member/service/DefaultMemberServiceUnitTest.java
@@ -24,7 +24,8 @@ class DefaultMemberServiceUnitTest {
 
     private final MemberRepository memberRepository = new JpaLikeInMemoryMemberRepository();
     private final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
-    private final EmailVerificationRepository emailVerificationRepository = new NoOpEmailVerificationRepository();
+    private final EmailVerificationRepository emailVerificationRepository =
+        new NoOpEmailVerificationRepository();
     private final String email = "test@example.com";
     private final String password = "test";
     private final String nickname = "test";


### PR DESCRIPTION
## ✅ PR 체크리스트
- [x] Assignee를 지정했나요?
- [x] 병합 브랜치를 확인했나요?
- [x] 관련 이슈를 연결했나요?
- [x] 로컬 빌드에 성공했나요?

## 📝 변경 내용
- 이메일 인증 기능을 구현했습니다.
- EmailVerification(이메일, 토큰, 검증여부를 담고 있는 엔티티)의 만료 관련 기능을 Redis 의 TTL을 활용하면 좋을 것 같습니다.
- 논의 후 반영 하겠습니다.

- 인증 코드 메일 verification.html 예시
<img width="934" height="951" alt="image" src="https://github.com/user-attachments/assets/a0963934-dce4-4533-8898-7767f707c98f" />


## 📎 관련 이슈
- close #93 