### PR TITLE
fix: Access Token 재발급 401 에러 해결

### DIFF
--- a/src/main/java/com/parksupark/soomjae/server/auth/username/security/UsernamePasswordSecurityConfig.java
+++ b/src/main/java/com/parksupark/soomjae/server/auth/username/security/UsernamePasswordSecurityConfig.java
@@ -69,7 +69,8 @@ public class UsernamePasswordSecurityConfig {
             .securityMatcher("/v1/members/create-member", "/v1/auth/refresh")
             .csrf(AbstractHttpConfigurer::disable)
             .formLogin(AbstractHttpConfigurer::disable)
-            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .sessionManagement(
+                session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
         return http.build();
     }

--- a/src/main/java/com/parksupark/soomjae/server/auth/username/security/UsernamePasswordSecurityConfig.java
+++ b/src/main/java/com/parksupark/soomjae/server/auth/username/security/UsernamePasswordSecurityConfig.java
@@ -18,6 +18,7 @@ import org.springframework.security.config.annotation.authentication.configurati
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -40,45 +41,53 @@ public class UsernamePasswordSecurityConfig {
     @Value("${app.cookie.secure}")
     private boolean cookieSecure;
 
-    /**
-     * <b>Why CSRF is disabled:</b>
-     * <ul>
-     *     <li>CSRF는 세션 기반 인증(stateful)에 대한 공격으로, JWT 기반 stateless 인증에는 의미 없음</li>
-     *     <li>불필요한 403 오류와 CSRF 토큰 처리 방지를 위해 disable함</li>
-     * </ul>
-     */
     @Bean
     @Order(3)
-    public SecurityFilterChain securityFilterChain(HttpSecurity http,
-            AuthenticationManager authenticationManager,
-            AuthenticationProvider authenticationProvider)
-            throws Exception {
+    public SecurityFilterChain publicEndPointFilterChain(HttpSecurity http,
+        AuthenticationManager authenticationManager) throws Exception {
 
         UsernamePasswordLoginFilter usernamePasswordLoginFilter = new UsernamePasswordLoginFilter(
-            authenticationManager, objectMapper, jwtProvider, refreshTokenService, cookieSecure);
+            authenticationManager, objectMapper, jwtProvider,
+            refreshTokenService, cookieSecure);
+
+        http
+            .securityMatcher("/v1/auth/login")
+            .csrf(AbstractHttpConfigurer::disable)
+            .formLogin(AbstractHttpConfigurer::disable)
+            .sessionManagement(
+                session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+            .addFilterAt(usernamePasswordLoginFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    @Order(4)
+    public SecurityFilterChain publicEndpointsFilterChain(HttpSecurity http) throws Exception {
+        http
+            .securityMatcher("/v1/members/create-member", "/v1/auth/refresh")
+            .csrf(AbstractHttpConfigurer::disable)
+            .formLogin(AbstractHttpConfigurer::disable)
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+        return http.build();
+    }
+
+    @Bean
+    @Order(5)
+    public SecurityFilterChain securityFilterChain(HttpSecurity http,
+        AuthenticationProvider authenticationProvider) throws Exception {
 
         http
             .securityMatcher("/**")
-                .csrf(csrf -> csrf.disable())
-
-                .formLogin(form -> form.disable())
-
-                .sessionManagement(session ->
-                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/login", "/v1/members/create-member").permitAll()
-                        .anyRequest().permitAll()
-                )
-
-                .authenticationProvider(authenticationProvider)
-
-                .authenticationManager(authenticationManager)
-
-                .addFilterBefore(jwtAuthenticationFilter(),
-                        UsernamePasswordAuthenticationFilter.class)
-                .addFilterAt(usernamePasswordLoginFilter,
-                        UsernamePasswordAuthenticationFilter.class);
+            .csrf(AbstractHttpConfigurer::disable)
+            .formLogin(AbstractHttpConfigurer::disable)
+            .sessionManagement(
+                session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+            .authenticationProvider(authenticationProvider)
+            .addFilterAt(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }


### PR DESCRIPTION
## ✅ PR 체크리스트
- [ ] Assignee를 지정했나요?
- [ ] 병합 브랜치를 확인했나요?
- [ ] 관련 이슈를 연결했나요?
- [ ] 로컬 빌드에 성공했나요?

## 📝 변경 내용
- /v1/auth/refresh 경로에 적용되고 있던 JwtAuthenticationFilter(요청에 만료된 access token이 포함되어있으면 401 반환) 을 적용 해제 시켰습니다.

## 📎 관련 이슈
- close #122 