### PR TITLE
MeetingPost & CommunityPost 오류 수정 및 미 로그인 상태로 로그인 필요 엔드포인트로 요청시 401 반환

### DIFF
--- a/src/main/java/com/parksupark/soomjae/server/auth/common/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/parksupark/soomjae/server/auth/common/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,35 @@
+package com.parksupark.soomjae.server.auth.common.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+        AuthenticationException authException) throws IOException, ServletException {
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        String jsonResponse = objectMapper.writeValueAsString(
+            Map.of("status", 401, "message", "로그인이 필요한 요청입니다.")
+        );
+
+        response.getWriter().write(jsonResponse);
+    }
+}

--- a/src/main/java/com/parksupark/soomjae/server/auth/username/security/UsernamePasswordSecurityConfig.java
+++ b/src/main/java/com/parksupark/soomjae/server/auth/username/security/UsernamePasswordSecurityConfig.java
@@ -91,7 +91,8 @@ public class UsernamePasswordSecurityConfig {
             .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
             .authenticationProvider(authenticationProvider)
             .addFilterAt(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
-            .exceptionHandling(exception -> exception.authenticationEntryPoint(authenticationEntryPoint));
+            .exceptionHandling(
+                exception -> exception.authenticationEntryPoint(authenticationEntryPoint));
 
         return http.build();
     }

--- a/src/main/java/com/parksupark/soomjae/server/auth/username/security/UsernamePasswordSecurityConfig.java
+++ b/src/main/java/com/parksupark/soomjae/server/auth/username/security/UsernamePasswordSecurityConfig.java
@@ -1,6 +1,7 @@
 package com.parksupark.soomjae.server.auth.username.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.parksupark.soomjae.server.auth.common.handler.CustomAuthenticationEntryPoint;
 import com.parksupark.soomjae.server.auth.jwt.JwtProvider;
 import com.parksupark.soomjae.server.auth.jwt.filter.JwtAuthenticationFilter;
 import com.parksupark.soomjae.server.auth.jwt.service.RefreshTokenService;
@@ -37,6 +38,7 @@ public class UsernamePasswordSecurityConfig {
     private final PasswordEncoder passwordEncoder;
     private final UserDetailsService userDetailsService;
     private final RefreshTokenService refreshTokenService;
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
 
     @Value("${app.cookie.secure}")
     private boolean cookieSecure;
@@ -88,7 +90,8 @@ public class UsernamePasswordSecurityConfig {
                 session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
             .authenticationProvider(authenticationProvider)
-            .addFilterAt(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+            .addFilterAt(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
+            .exceptionHandling(exception -> exception.authenticationEntryPoint(authenticationEntryPoint));
 
         return http.build();
     }

--- a/src/main/java/com/parksupark/soomjae/server/community/post/communitypost/controller/CommunityPostController.java
+++ b/src/main/java/com/parksupark/soomjae/server/community/post/communitypost/controller/CommunityPostController.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,6 +29,7 @@ public class CommunityPostController {
     private final CommunityPostService communityPostService;
 
     @PostMapping("/v1/boards/community/posts")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<Map<String, Object>> postCommunityPost(
         @RequestBody CommunityPostRequest communityPostRequest,
         @AuthenticationPrincipal
@@ -71,15 +73,19 @@ public class CommunityPostController {
 
     //수정
     @PutMapping("/v1/boards/community/posts/{postId}")
+    @PreAuthorize("isAuthenticated()")
     ResponseEntity<Long> putCommunityPost(@PathVariable Long postId,
-        @RequestBody CommunityPostRequest request) {
-        return ResponseEntity.ok(communityPostService.update(postId, request));
+        @RequestBody CommunityPostRequest request,
+        @AuthenticationPrincipal UsernamePasswordUserDetails userDetails) {
+        return ResponseEntity.ok(communityPostService.update(postId, request, userDetails));
     }
 
     //삭제
     @DeleteMapping("/v1/boards/community/posts/{postId}")
-    ResponseEntity<Void> deleteCommunityPost(@PathVariable Long postId) {
-        communityPostService.delete(postId);
+    @PreAuthorize("isAuthenticated()")
+    ResponseEntity<Void> deleteCommunityPost(@PathVariable Long postId,
+        @AuthenticationPrincipal UsernamePasswordUserDetails userDetails) {
+        communityPostService.delete(postId, userDetails);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/parksupark/soomjae/server/community/post/communitypost/service/CommunityPostService.java
+++ b/src/main/java/com/parksupark/soomjae/server/community/post/communitypost/service/CommunityPostService.java
@@ -5,6 +5,8 @@ import static com.parksupark.soomjae.server.community.category.constant.Category
 import static com.parksupark.soomjae.server.community.common.constant.PostConstant.COMMUNITY_POST_TYPE;
 
 import com.parksupark.soomjae.server.auth.username.dto.UsernamePasswordUserDetails;
+import com.parksupark.soomjae.server.common.exception.ErrorMessages;
+import com.parksupark.soomjae.server.common.exception.ResourceOwnershipException;
 import com.parksupark.soomjae.server.community.category.entity.Category;
 import com.parksupark.soomjae.server.community.category.repository.CategoryRepository;
 import com.parksupark.soomjae.server.community.comment.dto.CommentResponse;
@@ -80,8 +82,13 @@ public class CommunityPostService {
                 COMMUNITY_POST_TYPE, communityPost.getId()).stream().map(CommentResponse::of)
             .toList();
 
-        Boolean isLikedByMe = likeRepository.existsByPostTypeAndPostIdAndMemberId(
-            COMMUNITY_POST_TYPE, communityPost.getId(), userDetails.getMember().getId());
+        boolean isLikedByMe;
+        if (userDetails == null) {
+            isLikedByMe = false;
+        } else {
+            isLikedByMe = likeRepository.existsByPostTypeAndPostIdAndMemberId(
+                COMMUNITY_POST_TYPE, communityPost.getId(), userDetails.getMember().getId());
+        }
 
         Long likeNum = likeRepository.countByPostTypeAndPostId(COMMUNITY_POST_TYPE,
             communityPost.getId());
@@ -91,9 +98,15 @@ public class CommunityPostService {
 
 
     @Transactional
-    public Long update(Long communityPostId, CommunityPostRequest communityPostRequest) {
+    public Long update(Long communityPostId, CommunityPostRequest communityPostRequest,
+        UsernamePasswordUserDetails userDetails) {
         CommunityPost communityPost = communityPostRepository.findById(communityPostId)
             .orElseThrow(() -> new IllegalStateException(COMMUNITY_POST_NOT_FOUND));
+
+        if (!communityPost.getMember().getId().equals(userDetails.getMember().getId())) {
+            throw new ResourceOwnershipException(ErrorMessages.POST_OWNER_MISMATCH_MESSAGE);
+        }
+
         updateCommunityPost(communityPostRequest, communityPost);
         return communityPost.getId();
     }
@@ -109,9 +122,14 @@ public class CommunityPostService {
     }
 
     @Transactional
-    public void delete(Long postId) {
+    public void delete(Long postId, UsernamePasswordUserDetails userDetails) {
         CommunityPost communityPost = communityPostRepository.findById(postId)
             .orElseThrow(() -> new IllegalStateException(COMMUNITY_POST_NOT_FOUND));
+
+        if (!communityPost.getMember().getId().equals(userDetails.getMember().getId())) {
+            throw new ResourceOwnershipException(ErrorMessages.POST_OWNER_MISMATCH_MESSAGE);
+        }
+
         communityPostRepository.delete(communityPost);
     }
 

--- a/src/main/java/com/parksupark/soomjae/server/community/post/meetingpost/controller/MeetingPostController.java
+++ b/src/main/java/com/parksupark/soomjae/server/community/post/meetingpost/controller/MeetingPostController.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -32,6 +33,7 @@ public class MeetingPostController {
     private final MeetingPostService meetingPostService;
 
     @PostMapping("/v1/boards/meeting/posts")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<Map<String, Object>> postMeetingPost(
         @RequestBody MeetingPostRequest postRequest,
         @AuthenticationPrincipal
@@ -74,28 +76,37 @@ public class MeetingPostController {
 
     //수정
     @PutMapping("/v1/boards/meeting/posts/{postId}")
+    @PreAuthorize("isAuthenticated()")
     ResponseEntity<Long> putMeetingPost(@PathVariable Long postId,
-        @RequestBody MeetingPostRequest request) {
-        return ResponseEntity.ok(meetingPostService.update(postId, request));
+        @RequestBody MeetingPostRequest request,
+        @AuthenticationPrincipal UsernamePasswordUserDetails userDetails) {
+        return ResponseEntity.ok(
+            meetingPostService.update(postId, request, userDetails));
     }
 
     //삭제
     @DeleteMapping("/v1/boards/meeting/posts/{postId}")
-    ResponseEntity<Void> deleteMeetingPost(@PathVariable Long postId) {
-        meetingPostService.delete(postId);
+    @PreAuthorize("isAuthenticated()")
+    ResponseEntity<Void> deleteMeetingPost(@PathVariable Long postId,
+        @AuthenticationPrincipal UsernamePasswordUserDetails userDetails) {
+
+        meetingPostService.delete(postId, userDetails);
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/v1/boards/meeting/posts/{postId}/join")
+    @PreAuthorize("isAuthenticated()")
     ResponseEntity<ParticipationResponse> createParticipation(@PathVariable Long postId,
         @AuthenticationPrincipal UsernamePasswordUserDetails userDetails) {
         return ResponseEntity.ok(meetingPostService.participate(postId, userDetails));
     }
 
     @DeleteMapping("/v1/boards/meeting/posts/{postId}/join")
+    @PreAuthorize("isAuthenticated()")
     ResponseEntity<String> deleteParticipation(@PathVariable Long postId,
         @AuthenticationPrincipal UsernamePasswordUserDetails userDetails) {
-        return ResponseEntity.ok(meetingPostService.cancelParticipation(postId, userDetails));
+        return ResponseEntity.ok(
+            meetingPostService.cancelParticipation(postId, userDetails));
     }
 
     @GetMapping("/v1/boards/meeting/posts/{postId}/participants")

--- a/src/main/java/com/parksupark/soomjae/server/community/post/meetingpost/service/MeetingPostService.java
+++ b/src/main/java/com/parksupark/soomjae/server/community/post/meetingpost/service/MeetingPostService.java
@@ -9,6 +9,8 @@ import static com.parksupark.soomjae.server.community.category.constant.Category
 import static com.parksupark.soomjae.server.community.common.constant.PostConstant.MEETING_POST_TYPE;
 
 import com.parksupark.soomjae.server.auth.username.dto.UsernamePasswordUserDetails;
+import com.parksupark.soomjae.server.common.exception.ErrorMessages;
+import com.parksupark.soomjae.server.common.exception.ResourceOwnershipException;
 import com.parksupark.soomjae.server.community.category.entity.Category;
 import com.parksupark.soomjae.server.community.category.repository.CategoryRepository;
 import com.parksupark.soomjae.server.community.comment.dto.CommentResponse;
@@ -107,16 +109,23 @@ public class MeetingPostService {
                 MEETING_POST_TYPE, meetingPost.getId()).stream().map(CommentResponse::of)
             .toList();
 
-        Boolean isLikedByMe = likeRepository.existsByPostTypeAndPostIdAndMemberId(
-            MEETING_POST_TYPE, meetingPost.getId(), userDetails.getMember().getId());
+        boolean isLikedByMe;
+        boolean isParticipatedByMe;
+        if (userDetails == null) {
+            isLikedByMe = false;
+            isParticipatedByMe = false;
+        } else {
+            isLikedByMe = likeRepository.existsByPostTypeAndPostIdAndMemberId(
+                MEETING_POST_TYPE, meetingPost.getId(), userDetails.getMember().getId());
+
+            isParticipatedByMe =  participationRepository.existsByMeetingPostIdAndParticipantId(
+                postId, userDetails.getMember().getId());
+        }
 
         Long likeNum = likeRepository.countByPostTypeAndPostId(MEETING_POST_TYPE,
             meetingPost.getId());
 
         long currentParticipantCount = participationRepository.countByMeetingPostId(postId);
-
-        boolean isParticipatedByMe = participationRepository.existsByMeetingPostIdAndParticipantId(
-            postId, userDetails.getMember().getId());
 
         return MeetingPostDetailResponse.of(meetingPost, likeNum, isLikedByMe, comments,
             (int) currentParticipantCount, isParticipatedByMe);
@@ -124,9 +133,16 @@ public class MeetingPostService {
 
 
     @Transactional
-    public Long update(Long meetingPostId, MeetingPostRequest meetingPostRequest) {
+    public Long update(Long meetingPostId, MeetingPostRequest meetingPostRequest,
+        UsernamePasswordUserDetails userDetails) {
+
         MeetingPost meetingPost = meetingPostRepository.findById(meetingPostId)
             .orElseThrow(() -> new IllegalStateException(MEETING_POST_NOT_FOUND));
+
+        if (!meetingPost.getMember().getId().equals(userDetails.getMember().getId())) {
+            throw new ResourceOwnershipException(ErrorMessages.POST_OWNER_MISMATCH_MESSAGE);
+        }
+
         updateCommunityPost(meetingPostRequest, meetingPost);
         return meetingPost.getId();
     }
@@ -143,9 +159,15 @@ public class MeetingPostService {
     }
 
     @Transactional
-    public void delete(Long postId) {
+    public void delete(Long postId, UsernamePasswordUserDetails userDetails) {
+
         MeetingPost meetingPost = meetingPostRepository.findById(postId)
             .orElseThrow(() -> new IllegalStateException(MEETING_POST_NOT_FOUND));
+
+        if (!meetingPost.getMember().getId().equals(userDetails.getMember().getId())) {
+            throw new ResourceOwnershipException(ErrorMessages.POST_OWNER_MISMATCH_MESSAGE);
+        }
+
         meetingPostRepository.delete(meetingPost);
     }
 
@@ -189,7 +211,6 @@ public class MeetingPostService {
 
     @Transactional
     public String cancelParticipation(Long postId, UsernamePasswordUserDetails userDetails) {
-        Member participant = userDetails.getMember();
 
         MeetingPost meetingPost = meetingPostRepository.findById(postId)
             .orElseThrow(() -> new IllegalStateException(
@@ -200,7 +221,7 @@ public class MeetingPostService {
         }
 
         Participation participation = participationRepository.findByMeetingPostIdAndParticipantId(
-                postId, participant.getId())
+                postId, userDetails.getMember().getId())
             .orElseThrow(() -> new IllegalStateException(NOT_PARTICIPANT_OF_POST));
 
         participationRepository.delete(participation);


### PR DESCRIPTION
## ✅ PR 체크리스트
- [x] Assignee를 지정했나요?
- [x] 병합 브랜치를 확인했나요?
- [x] 관련 이슈를 연결했나요?
- [x] 로컬 빌드에 성공했나요?

## 📝 변경 내용
- userDetails에서 발생할 수 있는 NPE 방지 로직 적용
- 로그인 필요 요청에 @PreAuthorize("isAuthenticated") 적용
- 수정 삭제 요청에 작성자 본인 확인 로직 추가
- @PreAuthorize("isAuthenticated") 위배시 401 반환
```
{
    "status": 401,
    "message": "로그인이 필요한 요청입니다."
}
```

## 📎 관련 이슈
- close #132 