### PR TITLE
fix: JwtAuthenticationFilter 글로벌 체인 등록 방지

### DIFF
--- a/src/main/java/com/parksupark/soomjae/server/auth/username/security/UsernamePasswordSecurityConfig.java
+++ b/src/main/java/com/parksupark/soomjae/server/auth/username/security/UsernamePasswordSecurityConfig.java
@@ -9,6 +9,7 @@ import com.parksupark.soomjae.server.auth.username.filter.UsernamePasswordLoginF
 import com.parksupark.soomjae.server.common.filter.RequestLoggingFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -122,6 +123,16 @@ public class UsernamePasswordSecurityConfig {
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter() {
         return new JwtAuthenticationFilter(jwtProvider);
+    }
+
+    // 글로벌 필터 체인에 미포함
+    @Bean
+    public FilterRegistrationBean<JwtAuthenticationFilter> jwtAuthenticationFilterRegistration(
+        JwtAuthenticationFilter filter) {
+        FilterRegistrationBean<JwtAuthenticationFilter> registrationBean = new FilterRegistrationBean<>(
+            filter);
+        registrationBean.setEnabled(false);
+        return registrationBean;
     }
 
 }

--- a/src/main/java/com/parksupark/soomjae/server/auth/username/security/UsernamePasswordSecurityConfig.java
+++ b/src/main/java/com/parksupark/soomjae/server/auth/username/security/UsernamePasswordSecurityConfig.java
@@ -129,8 +129,8 @@ public class UsernamePasswordSecurityConfig {
     @Bean
     public FilterRegistrationBean<JwtAuthenticationFilter> jwtAuthenticationFilterRegistration(
         JwtAuthenticationFilter filter) {
-        FilterRegistrationBean<JwtAuthenticationFilter> registrationBean = new FilterRegistrationBean<>(
-            filter);
+        FilterRegistrationBean<JwtAuthenticationFilter> registrationBean =
+            new FilterRegistrationBean<>(filter);
         registrationBean.setEnabled(false);
         return registrationBean;
     }


### PR DESCRIPTION
## ✅ PR 체크리스트
- [x] Assignee를 지정했나요?
- [x] 병합 브랜치를 확인했나요?
- [x] 관련 이슈를 연결했나요?
- [x] 로컬 빌드에 성공했나요?

## 📝 변경 내용
- JwtAuthenticationFilter가 Spring Boot 기본 설정에 의해 자동으로 글로벌 체인에 등록되는 것을 막았습니다.

## 📎 관련 이슈
- close #136 