### PR TITLE
커뮤니티 포스트, 미팅 포스트 리스트 응답 필터 추가

### DIFF
--- a/src/main/java/com/parksupark/soomjae/server/common/exception/ErrorMessages.java
+++ b/src/main/java/com/parksupark/soomjae/server/common/exception/ErrorMessages.java
@@ -3,6 +3,8 @@ package com.parksupark.soomjae.server.common.exception;
 public class ErrorMessages {
 
     public static final String COMMUNITY_POST_NOT_FOUND = "게시글을 찾을 수 없습니다.";
+
+    public static final String OWNER_MISMATCH_EXCEPTION = "본인이 작성한 글은 상태를 변경할 수 없습니다.";
     public static final String MEETING_POST_NOT_FOUND = "모임 게시글을 찾을 수 없습니다.";
     public static final String INVALID_POST_TYPE_EXCEPTION_MESSAGE = "잘못된 요청입니다.";
     public static final String NOT_PARTICIPANT_OF_POST = "이 모임에 참여 중이지 않습니다.";

--- a/src/main/java/com/parksupark/soomjae/server/community/post/communitypost/controller/CommunityPostController.java
+++ b/src/main/java/com/parksupark/soomjae/server/community/post/communitypost/controller/CommunityPostController.java
@@ -65,7 +65,7 @@ public class CommunityPostController {
     ResponseEntity<PostListResponse> getCommunityList(
         @PageableDefault(size = 10, page = 0) Pageable pageable,
         @RequestParam(value = "categoryId", required = false) List<Long> categoryIds,
-        @RequestParam(value = "locationId", required = false) List<Long> locationIds,
+        @RequestParam(value = "locationCodes", required = false) List<Long> locationCodes,
         @RequestParam(value = "keyword", required = false) String keyword,
         @AuthenticationPrincipal UsernamePasswordUserDetails userDetails
     ) {
@@ -74,7 +74,7 @@ public class CommunityPostController {
 
         return ResponseEntity.ok(
             communityPostService.readCommunityPostList(
-                zeroBasedPageable, categoryIds, locationIds, keyword, userDetails
+                zeroBasedPageable, categoryIds, locationCodes, keyword, userDetails
             )
         );
     }

--- a/src/main/java/com/parksupark/soomjae/server/community/post/communitypost/controller/CommunityPostController.java
+++ b/src/main/java/com/parksupark/soomjae/server/community/post/communitypost/controller/CommunityPostController.java
@@ -6,6 +6,7 @@ import com.parksupark.soomjae.server.community.post.communitypost.dto.CommunityP
 import com.parksupark.soomjae.server.community.post.communitypost.dto.CommunityPostResponseWithComments;
 import com.parksupark.soomjae.server.community.post.communitypost.service.CommunityPostService;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 
@@ -62,11 +64,19 @@ public class CommunityPostController {
     @GetMapping("/v1/boards/community/posts/list")
     ResponseEntity<PostListResponse> getCommunityList(
         @PageableDefault(size = 10, page = 0) Pageable pageable,
-        @AuthenticationPrincipal UsernamePasswordUserDetails userDetails) {
+        @RequestParam(value = "categoryId", required = false) List<Long> categoryIds,
+        @RequestParam(value = "locationId", required = false) List<Long> locationIds,
+        @RequestParam(value = "keyword", required = false) String keyword,
+        @AuthenticationPrincipal UsernamePasswordUserDetails userDetails
+    ) {
         Pageable zeroBasedPageable = Pageable.ofSize(pageable.getPageSize())
             .withPage(Math.max(pageable.getPageNumber() - 1, 0));
+
         return ResponseEntity.ok(
-            communityPostService.readCommunityPostList(zeroBasedPageable, userDetails));
+            communityPostService.readCommunityPostList(
+                zeroBasedPageable, categoryIds, locationIds, keyword, userDetails
+            )
+        );
     }
 
     //수정

--- a/src/main/java/com/parksupark/soomjae/server/community/post/communitypost/repository/CommunityPostRepository.java
+++ b/src/main/java/com/parksupark/soomjae/server/community/post/communitypost/repository/CommunityPostRepository.java
@@ -37,13 +37,13 @@ public interface CommunityPostRepository extends JpaRepository<CommunityPost, Lo
     @Query("""
             SELECT p FROM CommunityPost p
             WHERE (:categoryIds IS NULL OR p.category.id IN :categoryIds)
-              AND (:locationIds IS NULL OR p.location.code IN :locationIds)
+              AND (:locationIds IS NULL OR p.location.code IN :locationCodes)
               AND (:keyword IS NULL OR LOWER(p.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
                    OR LOWER(p.content) LIKE LOWER(CONCAT('%', :keyword, '%')))
         """)
     Page<CommunityPost> searchByCategoriesAndLocationsAndKeyword(
         @Param("categoryIds") List<Long> categoryIds,
-        @Param("locationIds") List<Long> locationIds,
+        @Param("locationIds") List<Long> locationCodes,
         @Param("keyword") String keyword,
         Pageable pageable
     );

--- a/src/main/java/com/parksupark/soomjae/server/community/post/communitypost/repository/CommunityPostRepository.java
+++ b/src/main/java/com/parksupark/soomjae/server/community/post/communitypost/repository/CommunityPostRepository.java
@@ -33,5 +33,19 @@ public interface CommunityPostRepository extends JpaRepository<CommunityPost, Lo
         """)
     List<CommunityPostStatsResponse> findPostStats(@Param("postIds") List<Long> postIds,
         @Param("memberId") Long memberId);
+
+    @Query("""
+            SELECT p FROM CommunityPost p
+            WHERE (:categoryIds IS NULL OR p.category.id IN :categoryIds)
+              AND (:locationIds IS NULL OR p.location.code IN :locationIds)
+              AND (:keyword IS NULL OR LOWER(p.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                   OR LOWER(p.content) LIKE LOWER(CONCAT('%', :keyword, '%')))
+        """)
+    Page<CommunityPost> searchByCategoriesAndLocationsAndKeyword(
+        @Param("categoryIds") List<Long> categoryIds,
+        @Param("locationIds") List<Long> locationIds,
+        @Param("keyword") String keyword,
+        Pageable pageable
+    );
 }
 

--- a/src/main/java/com/parksupark/soomjae/server/community/post/communitypost/service/CommunityPostService.java
+++ b/src/main/java/com/parksupark/soomjae/server/community/post/communitypost/service/CommunityPostService.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -54,12 +55,28 @@ public class CommunityPostService {
     }
 
 
-    public PostListResponse readCommunityPostList(Pageable pageable,
-        UsernamePasswordUserDetails userDetails) {
-        List<CommunityPost> posts = communityPostRepository.findAll(pageable).getContent();
+    public PostListResponse readCommunityPostList(
+        Pageable pageable,
+        List<Long> categoryIds,
+        List<Long> locationIds,
+        String keyword,
+        UsernamePasswordUserDetails userDetails
+    ) {
+        List<Long> normalizedCategoryIds =
+            (categoryIds == null || categoryIds.isEmpty()) ? null : categoryIds;
+        List<Long> normalizedLocationIds =
+            (locationIds == null || locationIds.isEmpty()) ? null : locationIds;
+        String normalizedKeyword =
+            (keyword == null || keyword.isBlank()) ? null : keyword.trim();
+
+        Page<CommunityPost> filteredList = communityPostRepository
+            .searchByCategoriesAndLocationsAndKeyword(
+                normalizedCategoryIds, normalizedLocationIds, normalizedKeyword, pageable
+            );
+
+        List<CommunityPost> posts = filteredList.getContent();
         Long memberId = (userDetails != null) ? userDetails.getMember().getId() : null;
-        List<CommunityPostResponse> response = getCommunityPostResponses(posts,
-            memberId);
+        List<CommunityPostResponse> response = getCommunityPostResponses(posts, memberId);
         return PostListResponse.of(response);
     }
 

--- a/src/main/java/com/parksupark/soomjae/server/community/post/communitypost/service/CommunityPostService.java
+++ b/src/main/java/com/parksupark/soomjae/server/community/post/communitypost/service/CommunityPostService.java
@@ -58,14 +58,14 @@ public class CommunityPostService {
     public PostListResponse readCommunityPostList(
         Pageable pageable,
         List<Long> categoryIds,
-        List<Long> locationIds,
+        List<Long> locationCodes,
         String keyword,
         UsernamePasswordUserDetails userDetails
     ) {
         List<Long> normalizedCategoryIds =
             (categoryIds == null || categoryIds.isEmpty()) ? null : categoryIds;
         List<Long> normalizedLocationIds =
-            (locationIds == null || locationIds.isEmpty()) ? null : locationIds;
+            (locationCodes == null || locationCodes.isEmpty()) ? null : locationCodes;
         String normalizedKeyword =
             (keyword == null || keyword.isBlank()) ? null : keyword.trim();
 

--- a/src/main/java/com/parksupark/soomjae/server/community/post/meetingpost/controller/MeetingPostController.java
+++ b/src/main/java/com/parksupark/soomjae/server/community/post/meetingpost/controller/MeetingPostController.java
@@ -103,4 +103,11 @@ public class MeetingPostController {
     ResponseEntity<ParticipantListResponse> readParticipants(@PathVariable Long postId) {
         return ResponseEntity.ok(meetingPostService.findAllParticipantsByPostId(postId));
     }
+
+    @PutMapping("/v1/boards/meeting/post/{postId}/end")
+    ResponseEntity<Void> endMeeting(@PathVariable Long postId,
+        @AuthenticationPrincipal UsernamePasswordUserDetails userDetails) {
+        meetingPostService.endMeeting(postId, userDetails);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/parksupark/soomjae/server/community/post/meetingpost/controller/MeetingPostController.java
+++ b/src/main/java/com/parksupark/soomjae/server/community/post/meetingpost/controller/MeetingPostController.java
@@ -10,6 +10,7 @@ import com.parksupark.soomjae.server.community.post.meetingpost.dto.MeetingPostR
 import com.parksupark.soomjae.server.community.post.meetingpost.dto.MeetingPostResponseWithComments;
 import com.parksupark.soomjae.server.community.post.meetingpost.service.MeetingPostService;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 
@@ -66,11 +68,16 @@ public class MeetingPostController {
     @GetMapping("/v1/boards/meeting/posts/list")
     ResponseEntity<PostListResponse> getMeetingPostList(
         @PageableDefault(size = 10, page = 0) Pageable pageable,
+        @RequestParam(value = "categoryId", required = false) List<Long> categoryIds,
+        @RequestParam(value = "locationCodes", required = false) List<Long> locationCodes,
+        @RequestParam(value = "keyword", required = false) String keyword,
+        @RequestParam(value = "recruitment", required = false) Boolean recruitment,
         @AuthenticationPrincipal UsernamePasswordUserDetails userDetails) {
         Pageable zeroBasedPageable = Pageable.ofSize(pageable.getPageSize())
             .withPage(Math.max(pageable.getPageNumber() - 1, 0));
         return ResponseEntity.ok(
-            meetingPostService.readMeetingPostList(zeroBasedPageable, userDetails));
+            meetingPostService.readMeetingPostList(zeroBasedPageable, categoryIds, locationCodes,
+                keyword, recruitment, userDetails));
     }
 
     //수정

--- a/src/main/java/com/parksupark/soomjae/server/community/post/meetingpost/entity/MeetingPost.java
+++ b/src/main/java/com/parksupark/soomjae/server/community/post/meetingpost/entity/MeetingPost.java
@@ -1,5 +1,7 @@
 package com.parksupark.soomjae.server.community.post.meetingpost.entity;
 
+import static com.parksupark.soomjae.server.community.post.meetingpost.entity.RecruitmentStatus.모집중;
+
 import com.parksupark.soomjae.server.common.entity.BaseEntity;
 import com.parksupark.soomjae.server.community.category.entity.Category;
 import com.parksupark.soomjae.server.community.location.entity.Location;
@@ -52,4 +54,7 @@ public class MeetingPost extends BaseEntity {
     private Instant startTime;
 
     private Instant endTime;
+
+    @Builder.Default
+    private RecruitmentStatus recruitmentStatus = 모집중;
 }

--- a/src/main/java/com/parksupark/soomjae/server/community/post/meetingpost/entity/RecruitmentStatus.java
+++ b/src/main/java/com/parksupark/soomjae/server/community/post/meetingpost/entity/RecruitmentStatus.java
@@ -1,0 +1,5 @@
+package com.parksupark.soomjae.server.community.post.meetingpost.entity;
+
+public enum RecruitmentStatus {
+    모집중, 모집종료
+}

--- a/src/main/java/com/parksupark/soomjae/server/community/post/meetingpost/repository/MeetingPostRepository.java
+++ b/src/main/java/com/parksupark/soomjae/server/community/post/meetingpost/repository/MeetingPostRepository.java
@@ -2,19 +2,22 @@ package com.parksupark.soomjae.server.community.post.meetingpost.repository;
 
 import com.parksupark.soomjae.server.community.post.meetingpost.dto.MeetingPostStatsResponse;
 import com.parksupark.soomjae.server.community.post.meetingpost.entity.MeetingPost;
+import com.parksupark.soomjae.server.community.post.meetingpost.entity.RecruitmentStatus;
 import jakarta.persistence.LockModeType;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface MeetingPostRepository extends JpaRepository<MeetingPost, Long> {
+public interface MeetingPostRepository extends JpaRepository<MeetingPost, Long>,
+    JpaSpecificationExecutor<MeetingPost> {
 
     Page<MeetingPost> findByMemberId(Long memberId, Pageable pageable);
 
@@ -42,5 +45,20 @@ public interface MeetingPostRepository extends JpaRepository<MeetingPost, Long> 
         """)
     List<MeetingPostStatsResponse> findPostStats(@Param("postIds") List<Long> postIds,
         @Param("memberId") Long memberId);
+
+    @Query("""
+        SELECT p FROM MeetingPost p
+        WHERE (:categoryIds IS NULL OR p.category.id IN :categoryIds)
+          AND (:locationIds IS NULL OR p.location.code IN :locationCodes)
+          AND (:kw IS NULL OR LOWER(p.title) LIKE :kw OR LOWER(p.content) LIKE :kw)
+          AND (:status IS NULL OR p.recruitmentStatus = :status)
+        """)
+    Page<MeetingPost> searchByFilters(
+        @Param("categoryIds") List<Long> categoryIds,
+        @Param("locationIds") List<Long> locationCodes,
+        @Param("kw") String keywordLike,
+        @Param("status") RecruitmentStatus status,
+        Pageable pageable
+    );
 }
 

--- a/src/main/java/com/parksupark/soomjae/server/community/post/meetingpost/service/MeetingPostService.java
+++ b/src/main/java/com/parksupark/soomjae/server/community/post/meetingpost/service/MeetingPostService.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -66,13 +67,53 @@ public class MeetingPostService {
         return meetingPostRepository.save(entity).getId();
     }
 
-    public PostListResponse readMeetingPostList(Pageable pageable,
-        UsernamePasswordUserDetails userDetails) {
-        List<MeetingPost> posts = meetingPostRepository.findAll(pageable).getContent();
+    public PostListResponse readMeetingPostList(
+        Pageable pageable,
+        List<Long> categoryIds,
+        List<Long> locationCodes,
+        String keyword,
+        Boolean recruitment,
+        UsernamePasswordUserDetails userDetails
+    ) {
+        List<Long> cat = normalizeList(categoryIds);
+        List<Long> loc = normalizeList(locationCodes);
+
+        String kw = normalizeKeyword(keyword);
+
+        RecruitmentStatus status = mapRecruitment(recruitment);
+
+        Page<MeetingPost> page = meetingPostRepository.searchByFilters(cat, loc, kw, status,
+            pageable);
+        List<MeetingPost> posts = page.getContent();
+
         Long memberId = (userDetails != null) ? userDetails.getMember().getId() : null;
-        List<MeetingPostResponse> response = getMeetingPostStats(posts,
-            memberId);
+
+        List<MeetingPostResponse> response = getMeetingPostStats(posts, memberId);
+
         return PostListResponse.of(response);
+    }
+
+    private List<Long> normalizeList(List<Long> ids) {
+        return (ids == null || ids.isEmpty()) ? null : ids;
+    }
+
+    private String normalizeKeyword(String keyword) {
+        if (keyword == null) {
+            return null;
+        }
+        String trimmed = keyword.trim();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+        String lowered = trimmed.toLowerCase();
+        return "%" + lowered + "%";
+    }
+
+    private RecruitmentStatus mapRecruitment(Boolean recruitment) {
+        if (recruitment == null) {
+            return null;
+        }
+        return recruitment ? RecruitmentStatus.모집중 : RecruitmentStatus.모집종료;
     }
 
     public PostListResponse readByMemberId(Long memberId, Pageable pageable) {

--- a/src/main/java/com/parksupark/soomjae/server/community/post/meetingpost/service/MeetingPostService.java
+++ b/src/main/java/com/parksupark/soomjae/server/community/post/meetingpost/service/MeetingPostService.java
@@ -9,6 +9,7 @@ import static com.parksupark.soomjae.server.community.category.constant.Category
 import static com.parksupark.soomjae.server.community.common.constant.PostConstant.MEETING_POST_TYPE;
 
 import com.parksupark.soomjae.server.auth.username.dto.UsernamePasswordUserDetails;
+import com.parksupark.soomjae.server.common.exception.ErrorMessages;
 import com.parksupark.soomjae.server.community.category.entity.Category;
 import com.parksupark.soomjae.server.community.category.repository.CategoryRepository;
 import com.parksupark.soomjae.server.community.comment.dto.CommentResponse;
@@ -27,6 +28,7 @@ import com.parksupark.soomjae.server.community.post.meetingpost.dto.MeetingPostR
 import com.parksupark.soomjae.server.community.post.meetingpost.dto.MeetingPostResponseWithComments;
 import com.parksupark.soomjae.server.community.post.meetingpost.dto.MeetingPostStatsResponse;
 import com.parksupark.soomjae.server.community.post.meetingpost.entity.MeetingPost;
+import com.parksupark.soomjae.server.community.post.meetingpost.entity.RecruitmentStatus;
 import com.parksupark.soomjae.server.community.post.meetingpost.repository.MeetingPostRepository;
 import com.parksupark.soomjae.server.member.dto.MemberResponse;
 import com.parksupark.soomjae.server.member.entity.Member;
@@ -212,5 +214,19 @@ public class MeetingPostService {
             participationRepository.findByMeetingPostId(postId).stream()
                 .map(participation -> MemberResponse.create(participation.getParticipant()))
                 .toList());
+    }
+
+    public void endMeeting(Long postId, UsernamePasswordUserDetails userDetails) {
+        MeetingPost meetingPost = meetingPostRepository.findById(postId)
+            .orElseThrow(() -> new IllegalStateException(MEETING_POST_NOT_FOUND));
+        Member loginUser = userDetails.getMember();
+        validatePostOwner(loginUser, meetingPost);
+        meetingPost.setRecruitmentStatus(RecruitmentStatus.모집종료);
+    }
+
+    private void validatePostOwner(Member loginUser, MeetingPost meetingPost) {
+        if (loginUser != meetingPost.getMember()) {
+            throw new IllegalStateException(ErrorMessages.OWNER_MISMATCH_EXCEPTION);
+        }
     }
 }


### PR DESCRIPTION
## ✅ PR 체크리스트
- [x] Assignee를 지정했나요?
- [x] 병합 브랜치를 확인했나요?
- [x] 관련 이슈를 연결했나요?
- [x] 로컬 빌드에 성공했나요?

## 📝 변경 내용
- 커뮤니티 포스트, 미팅 포스트 리스트 응답 필터 추가
커뮤니티 포스트 리스트 응답 api
/v1/boards/community/posts/list 기존 api에 
?categoryIds = 1, 3 ,7&
?locationCodes = 10001, 11000&
?keyword=숨재 와 같이 필터링 할 것을 추가해주시면 됩니다

미팅 포스트는 커뮤니티 포스트와 같고, recruitment=true or false로 모집 중인지 여부만 추가했습니다

## 📎 관련 이슈
- close #131